### PR TITLE
longest reads memory optimization

### DIFF
--- a/short-read-mngs/idseq-dag/idseq_dag/steps/generate_alignment_viz.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/steps/generate_alignment_viz.py
@@ -229,22 +229,13 @@ class PipelineStepGenerateAlignmentViz(PipelineStep):
         def align_viz_name(tag, lin_id):
             return f"{output_json_dir}/{db_type}.{tag}.{int(lin_id)}.align_viz.json"
 
-        def dig(obj: Dict, path, default=None):
-            res = obj
-            for k in path:
-                if type(res) is dict and k in res:
-                    res = res[k]
-                else:
-                    return default
-            return res
-
         def reads_from_dict(d):
-            read_arr_paths = [[k] for k in d.keys()]
-            while read_arr_paths and (not dig(d, read_arr_paths[0] + ["reads"], False)):
-                read_arr_paths = [path + [key] for path in read_arr_paths for key in dig(d, path, {}).keys()]
+            read_arrs = list(d.values())
+            while read_arrs and ("reads" not in read_arrs[0]):
+                read_arrs = [vv for v in read_arrs for vv in v.values()]
 
-            for read_arr_path in read_arr_paths:
-                for read_entry in dig(d, read_arr_path + ["reads"], []):
+            for read_arr in read_arrs:
+                for read_entry in read_arr.get("reads", []):
                     yield SeqRecord(Seq(read_entry[1]), id=read_entry[0], description="")
 
         def write_n_longest(tag, lin_id, d, n):

--- a/short-read-mngs/idseq-dag/idseq_dag/steps/generate_alignment_viz.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/steps/generate_alignment_viz.py
@@ -259,7 +259,7 @@ class PipelineStepGenerateAlignmentViz(PipelineStep):
                         duplicate = True
                         break
                     if len(read.seq) > len(r.seq):
-                        longest_n_reads = longest_n_reads[:i] + [read] + longest_n_reads[i:n-1]
+                        longest_n_reads = longest_n_reads[:i] + [read] + longest_n_reads[i:n - 1]
                         break
                 else:
                     if len(longest_n_reads) < n and not duplicate:

--- a/short-read-mngs/idseq-dag/idseq_dag/steps/generate_alignment_viz.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/steps/generate_alignment_viz.py
@@ -233,7 +233,7 @@ class PipelineStepGenerateAlignmentViz(PipelineStep):
             res = obj
             for k in path:
                 if type(res) is dict and k in res:
-                    res = obj[k]
+                    res = res[k]
                 else:
                     return default
             return res


### PR DESCRIPTION
This change should optimize the memory usage of longest reads dramatically. There have been some memory issues in this step since my change.

1. I was maintaining a set of all reads to enforce uniqueness. Instead I am now only adding a read to the longest n (5 in this case) reads if it is unique to them. This should cut down the amount of reads that need to be stored to enforce uniqueness by quite a lot.
2. I put all of the reads into a list, sorted it, and took the top n. I modified this so I can iterate through the reads and maintain a list of only the top n.