### PR TITLE
cleanup cache downloads

### DIFF
--- a/short-read-mngs/idseq_utils/idseq_utils/batch_run_helpers.py
+++ b/short-read-mngs/idseq_utils/idseq_utils/batch_run_helpers.py
@@ -250,7 +250,8 @@ def run_alignment(
     with Pool(MAX_CHUNKS_IN_FLIGHT) as p:
         p.starmap(_run_chunk, chunks)
     run(["s3parcp", "--recursive", chunk_dir, "chunks"], check=True)
-    shutil.rmtree(os.path.join("chunks", "cache"), ignore_errors=True)
+    if os.path.exists(os.path.join("chunks", "cache")):
+        shutil.rmtree(os.path.join("chunks", "cache"))
     for fn in listdir("chunks"):
         if fn.endswith("json"):
             os.remove(os.path.join("chunks", fn))


### PR DESCRIPTION
Fix call caching by removing the downloaded cache dir from the chunks directory for merging. It is a little inefficient to download stuff just to delete but these files will be quite small so I think the complexity of a more complicated downloader that skips these files isn't justified.