### PR TITLE
Explicitly remove czid_ from name

### DIFF
--- a/short-read-mngs/auto_benchmark/harvest.py
+++ b/short-read-mngs/auto_benchmark/harvest.py
@@ -228,7 +228,7 @@ def read_outputs_json(rundir):
     )
     ans = {}
     for key, value in items:
-        ans["czid_short_read_mngs." + key[6:]] = value
+        ans["czid_short_read_mngs." + key.lstrip("czid_")] = value
     return ans
 
 


### PR DESCRIPTION
* This used to remove "idseq_" from the workflow names, but now breaks because the name is "czid_*"