### PR TITLE
[SC-191192] Fix diamond sequence set index out of bounds error

### DIFF
--- a/short-read-mngs/idseq_utils/idseq_utils/diamond_scatter.py
+++ b/short-read-mngs/idseq_utils/idseq_utils/diamond_scatter.py
@@ -196,7 +196,7 @@ def blastx_join(chunk_dir: str, out: str, diamond_args: str, *query: str):
             diamond_blastx(
                 cwd=tmp_dir,
                 par_tmpdir="par-tmp",
-                block_size=1,
+                block_size=10,
                 database=db.name,
                 out=out,
                 join_chunks=chunks,


### PR DESCRIPTION
* When the block-size is too small on join, it can cut off the input query.  This causes a discrepancy between the size in the chunks vs on join. 
* This comes at a risk of running higher memory. Not sure if we will actually run out of memory if the query is too large. Given that we currently fail in any case, we might as well raise this param
* @morsecodist you might understand the block-size params better than me, especially since I haven't looked at the chunk steps, just the join. 