### PR TITLE
ignore warnings for diamond

### DIFF
--- a/index-generation/index_generation.wdl
+++ b/index-generation/index_generation.wdl
@@ -223,7 +223,8 @@ task GenerateIndexDiamond {
     }
 
     command <<<
-        diamond makedb --in ~{nr} -d diamond_index_chunksize_~{chunksize} --scatter-gather -b ~{chunksize}
+        # Ignore warning is needed because sometimes NR has sequences of only DNA characters which causes this to fail
+        diamond makedb --ignore-warnings --in ~{nr} -d diamond_index_chunksize_~{chunksize} --scatter-gather -b ~{chunksize}
     >>>
 
     output {


### PR DESCRIPTION
Some sequences in NR are only composed of DNA characters (ACTG). This causes makedb to fail as a safeguard because it appears that we are trying to use it on DNA instead of protein sequences. I inspected these sequences and it seems like in all of NR there do happen to be some sequences of only these characters. They are all valid protein characters as well. With such a large and imperfect data set running into these sequences is inevitable so I think we should ignore warnings.