### PR TITLE
Split GenerateIndexAccessions into substeps for more performance

### DIFF
--- a/index-generation/generate_loc_db.py
+++ b/index-generation/generate_loc_db.py
@@ -6,6 +6,7 @@ import dbm
 import re
 import shelve
 import sys
+import logging
 
 
 def generate_loc_db(db_file, loc_db_file, info_db_file):
@@ -24,7 +25,7 @@ def generate_loc_db(db_file, loc_db_file, info_db_file):
         for line in dbf:
             lines += 1
             if lines % 100000 == 0:
-                print(f"{lines/1000000.0}M lines")
+                logging.info(f"{lines/1000000.0}M lines")
             if line[0] == '>':  # header line
                 if seq_len > 0 and len(accession_id) > 0:
                     loc_dict[accession_id] = [seq_offset, header_len, seq_len]

--- a/index-generation/index_generation.wdl
+++ b/index-generation/index_generation.wdl
@@ -186,6 +186,7 @@ task GenerateIndexAccessions {
     input {
         File nr
         File nt
+        Int parallelism = 16
         Directory accession2taxid
         String docker_image_id
     }
@@ -201,6 +202,7 @@ task GenerateIndexAccessions {
             accession2taxid/nucl_gb.accession2taxid.gz \
             accession2taxid/pdb.accession2taxid.gz \
             accession2taxid/prot.accession2taxid.FULL.gz \
+            --parallelism ~{parallelism} \
             --nt_file ~{nt} \
             --nr_file ~{nr} \
             --output_gz accession2taxid.gz \

--- a/index-generation/index_generation.wdl
+++ b/index-generation/index_generation.wdl
@@ -40,6 +40,18 @@ workflow index_generation {
         docker_image_id = docker_image_id
     }
 
+    call GenerateNTDB {
+        input:
+        nt = DownloadNT.nt,
+        docker_image_id = docker_image_id
+    }
+
+    call GenerateNRDB {
+        input:
+        nr = DownloadNR.nr,
+        docker_image_id = docker_image_id
+    }
+
     call GenerateIndexDiamond {
         input:
         nr = DownloadNR.nr,
@@ -68,10 +80,10 @@ workflow index_generation {
         File accession2taxid_wgs = GenerateIndexAccessions.accession2taxid_wgs
         File accession2taxid_db = GenerateIndexAccessions.accession2taxid_db
         File taxid2wgs_accession_db = GenerateIndexAccessions.taxid2wgs_accession_db
-        File nt_loc_db = GenerateIndexAccessions.nt_loc_db
-        File nt_info_db = GenerateIndexAccessions.nt_info_db
-        File nr_loc_db = GenerateIndexAccessions.nr_loc_db
-        File nr_info_db = GenerateIndexAccessions.nr_info_db
+        File nt_loc_db = GenerateNTDB.nt_loc_db
+        File nt_info_db = GenerateNTDB.nt_info_db
+        File nr_loc_db = GenerateNRDB.nr_loc_db
+        File nr_info_db = GenerateNRDB.nr_info_db
         Directory diamond_index = GenerateIndexDiamond.diamond_index
         File taxid_lineages_db = GenerateIndexLineages.taxid_lineages_db
         File taxid_lineages_csv = GenerateIndexLineages.taxid_lineages_csv
@@ -195,8 +207,6 @@ task GenerateIndexAccessions {
             --output_wgs_gz accession2taxid_wgs.gz \
             --accession2taxid_db accession2taxid.db \
             --taxid2wgs_accession_db taxid2wgs_accession.db
-        python3 /usr/local/bin/generate_loc_db.py ~{nt} nt_loc.db nt_info.db
-        python3 /usr/local/bin/generate_loc_db.py ~{nr} nr_loc.db nr_info.db
     >>>
 
     output {
@@ -204,8 +214,44 @@ task GenerateIndexAccessions {
         File accession2taxid_wgs = "accession2taxid_wgs.gz"
         File accession2taxid_db = "accession2taxid.db"
         File taxid2wgs_accession_db = "taxid2wgs_accession.db"
+    }
+
+    runtime {
+        docker: docker_image_id
+    }
+}
+
+task GenerateNTDB {
+    input {
+        File nt
+        String docker_image_id
+    }
+
+    command <<<
+        python3 /usr/local/bin/generate_loc_db.py ~{nt} nt_loc.db nt_info.db
+    >>>
+
+    output {
         File nt_loc_db = "nt_loc.db"
         File nt_info_db = "nt_info.db"
+    }
+
+    runtime {
+        docker: docker_image_id
+    }
+}
+
+task GenerateNRDB {
+    input {
+        File nr
+        String docker_image_id
+    }
+
+    command <<<
+        python3 /usr/local/bin/generate_loc_db.py ~{nr} nr_loc.db nr_info.db
+    >>>
+
+    output {
         File nr_loc_db = "nr_loc.db"
         File nr_info_db = "nr_info.db"
     }


### PR DESCRIPTION
It actually turns out that we made our alignment indexes so fast that Accessions is the bottleneck. I remember back when alignment index generation took three days the 12 + hours of accessions seemed hardly worth worrying about. This is a super low hanging fruit optimization i realized when I studied the step. There is no reason to block generating the `_loc.db` and `_info.db` files on accessions so we can parallelize them easily by splitting them out into their own steps.

Sadly, generating the accession DB itself is still quite slow but optimizing that presents much more of a challenge. I found a parallelism setting in the code and I doubled it from 8 to 16 (we have 60 cores to work with so that should be good). However, the parallelism is only for the actual generation, I suspect it spends a lot of it's time in writing the output files to the Berkley DB format, which is not parallelized. The print statements were hidden because they write to stdout and miniwdl only logs from stderr so I switched to use logging and added a log before the write step so we can look at the logs to get an idea of how long it spends on each element. I think with minimal work we could dramatically increase the performance of generating the accession index. There is no reason this should take 10+ hours to run.