### PR TITLE
Add scatter gather parallelism to minimap2 chunks

### DIFF
--- a/index-generation/index_generation.wdl
+++ b/index-generation/index_generation.wdl
@@ -314,7 +314,7 @@ task ChunkNT {
     >>>
 
     output {
-        Array[File] nt_chunks = "nt.split/*"
+        Array[File] nt_chunks = glob("nt.split/*")
     }
 
     runtime {
@@ -340,7 +340,7 @@ task GenerateIndexMinimap2Chunk {
     >>>
 
     output {
-        File minimap2_index = "nt.part_*.idx"
+        File minimap2_index = glob("nt.part_*.idx")[0]
     }
 
     runtime {


### PR DESCRIPTION
I want to test through with https://github.com/chanzuckerberg/czid-workflows/pull/56 before merging this. There are also some difficulties with path stuff because outputting a file array instead of a directory will flatten the structure. I can fuse them in a downstream step but that will result in way more space usage for no good reason. We could also use GNU parallel for parallelism here. It is less pleasant than miniwdl imo. So I won't merge this until I work those issues out and it may be a waste of time because this is not the rate limiting step (yet).