### PR TITLE
Index turbo

### DIFF
--- a/index-generation/Dockerfile
+++ b/index-generation/Dockerfile
@@ -27,8 +27,11 @@ RUN apt-get update && \
         python3-pip \
         software-properties-common
 
-# Install s3parcp
-RUN curl -Ls https://github.com/chanzuckerberg/s3parcp/releases/download/v0.2.0-alpha/s3parcp_0.2.0-alpha_Linux_x86_64.tar.gz | tar -C /usr/bin -xz s3parcp
+# install aria2
+WORKDIR /tmp
+RUN git clone https://github.com/aria2/aria2.git
+WORKDIR /tmp/aria2
+RUN ./configure && make && mv ./src/aria2c /usr/local/bin/
 
 # install minimap2 and seqkit
 RUN git clone --single-branch --branch distributed-mapping  https://github.com/mlin/minimap2.git \

--- a/index-generation/Dockerfile
+++ b/index-generation/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:18.04
 ARG DEBIAN_FRONTEND=noninteractive
+ARG ARIA2_VERSION=1.36.0
 
 # Install dependencies
 RUN apt-get update && \
@@ -29,9 +30,9 @@ RUN apt-get update && \
 
 # install aria2
 WORKDIR /tmp
-RUN git clone https://github.com/aria2/aria2.git
-WORKDIR /tmp/aria2
-RUN ./configure && make && mv ./src/aria2c /usr/local/bin/
+RUN curl -L https://github.com/aria2/aria2/releases/download/release-${ARIA2_VERSION}/aria2-${ARIA2_VERSION}.tar.gz -o aria2-${ARIA2_VERSION}.tar.gz && \
+    tar xzvf aria2-${ARIA2_VERSION}.tar.gz
+RUN cd /tmp/aria2-${ARIA2_VERSION} && ./configure && make && mv ./src/aria2c /usr/local/bin/
 
 # install minimap2 and seqkit
 RUN git clone --single-branch --branch distributed-mapping  https://github.com/mlin/minimap2.git \

--- a/index-generation/Dockerfile
+++ b/index-generation/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 ARG DEBIAN_FRONTEND=noninteractive
 ARG ARIA2_VERSION=1.36.0
 
@@ -9,7 +9,7 @@ RUN apt-get update && \
         ## diamond
         g++ \
         gdb \
-        libclang-common-6.0-dev \
+        libclang-common-12-dev \
         cmake\
         g++\
         zlib1g-dev \
@@ -23,8 +23,9 @@ RUN apt-get update && \
         wget \
         liblz4-tool \
         libssl-dev \
+        pkg-config \
         pigz \
-        python-pandas \
+        python3-pandas \
         python3-gdbm \
         python3-pip \
         software-properties-common

--- a/index-generation/Dockerfile
+++ b/index-generation/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && \
 WORKDIR /tmp
 RUN curl -L https://github.com/aria2/aria2/releases/download/release-${ARIA2_VERSION}/aria2-${ARIA2_VERSION}.tar.gz -o aria2-${ARIA2_VERSION}.tar.gz && \
     tar xzvf aria2-${ARIA2_VERSION}.tar.gz
-RUN cd /tmp/aria2-${ARIA2_VERSION} && ./configure && make && mv ./src/aria2c /usr/local/bin/
+RUN cd /tmp/aria2-${ARIA2_VERSION} && ./configure --without-gnutls --with-openssl && make && mv ./src/aria2c /usr/local/bin/
 
 # install minimap2 and seqkit
 RUN git clone --single-branch --branch distributed-mapping  https://github.com/mlin/minimap2.git \

--- a/index-generation/Dockerfile
+++ b/index-generation/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && \
         git \
         wget \
         liblz4-tool \
+        libssl-dev \
         pigz \
         python-pandas \
         python3-gdbm \

--- a/index-generation/generate_accession2taxid.py
+++ b/index-generation/generate_accession2taxid.py
@@ -78,16 +78,15 @@ def grab_accession_names(source_file, dest_file):
                     dest.write(line.split(' ')[0] + "\n")
 
 
-def grab_accession_mapping_list(source_gz, num_partitions, partition_id,
+def grab_accession_mapping_list(source, num_partitions, partition_id,
                                 accessions, output_file):
     num_lines = 0
-    with open(output_file, 'w') as out, open(source_gz, 'r') as mapf:
-        for line_encoded in mapf:
+    with open(output_file, 'w') as out, open(source, 'r') as mapf:
+        for line in mapf:
             if num_lines % num_partitions == partition_id:
-                line = line_encoded.decode('utf-8')
                 accession_line = line.split("\t")
                 accession = accession_line[0]
-                # If using the prot.accession2taxid.FULL.gz file, should add a column with no version
+                # If using the prot.accession2taxid.FULL file, should add a column with no version
                 if len(accession_line) < 3 and accession.split(".")[0] in accessions:
                     accession_no_version = accession.split(".")[0]
                     out.write(f"{accession_no_version}\t{line}")
@@ -95,7 +94,7 @@ def grab_accession_mapping_list(source_gz, num_partitions, partition_id,
                     out.write(line)
             num_lines += 1
             if num_lines % 1000000 == 0:
-                print(f"{source_gz} partition {partition_id} line {num_lines/1000000}M", file=sys.stderr)
+                print(f"{source} partition {partition_id} line {num_lines/1000000}M", file=sys.stderr)
 
 
 if __name__ == '__main__':

--- a/index-generation/generate_accession2taxid.py
+++ b/index-generation/generate_accession2taxid.py
@@ -45,7 +45,6 @@ __note:__ columns 3 and 10 of the hitsummary2.xxx.tab files should always be ide
 """
 import argparse
 import dbm
-import gzip
 import logging
 import os
 import shelve
@@ -53,19 +52,17 @@ import sys
 from multiprocessing.pool import ThreadPool
 
 
-def output_dicts_to_db(mapping_files, accession2taxid_db, output_gz):
+def output_dicts_to_db(mapping_files, accession2taxid_db):
     # generate the accession2taxid db and file
     accession_dict = shelve.Shelf(dbm.ndbm.open(accession2taxid_db.replace(".db", ""), 'c'))  # type: ignore
-    with gzip.open(output_gz, "wt") as gzf:
-        for partition_list in mapping_files:
-            for partition in partition_list:
-                with open(partition, 'r', encoding="utf-8") as pf:
-                    for line in pf:
-                        if len(line) <= 1:
-                            break
-                        fields = line.rstrip().split("\t")
-                        accession_dict[fields[0]] = fields[2]
-                        gzf.write(line)
+    for partition_list in mapping_files:
+        for partition in partition_list:
+            with open(partition, 'r', encoding="utf-8") as pf:
+                for line in pf:
+                    if len(line) <= 1:
+                        break
+                    fields = line.rstrip().split("\t")
+                    accession_dict[fields[0]] = fields[2]
 
     accession_dict.close()
 
@@ -111,7 +108,6 @@ if __name__ == '__main__':
     num_partitions = args.parallelism
     nt_file = args.nt_file
     nr_file = args.nr_file
-    output_gz = args.output_gz
     accession2taxid_db = args.accession2taxid_db
 
     # Get accession_list
@@ -148,4 +144,4 @@ if __name__ == '__main__':
 
     logging.info("starting writing output dictionaries to db")
 
-    output_dicts_to_db(mapping_files, accession2taxid_db, output_gz)
+    output_dicts_to_db(mapping_files, accession2taxid_db)

--- a/index-generation/generate_accession2taxid.py
+++ b/index-generation/generate_accession2taxid.py
@@ -81,7 +81,7 @@ def grab_accession_names(source_file, dest_file):
 def grab_accession_mapping_list(source_gz, num_partitions, partition_id,
                                 accessions, output_file):
     num_lines = 0
-    with open(output_file, 'w') as out, gzip.open(source_gz, 'r') as mapf:
+    with open(output_file, 'w') as out, open(source_gz, 'r') as mapf:
         for line_encoded in mapf:
             if num_lines % num_partitions == partition_id:
                 line = line_encoded.decode('utf-8')

--- a/index-generation/generate_accession2taxid.py
+++ b/index-generation/generate_accession2taxid.py
@@ -46,6 +46,7 @@ __note:__ columns 3 and 10 of the hitsummary2.xxx.tab files should always be ide
 import argparse
 import dbm
 import gzip
+import os
 import shelve
 import logging
 from multiprocessing.pool import ThreadPool
@@ -161,7 +162,7 @@ if __name__ == '__main__':
     for accession_mapping_file in accession_mapping_files:
         partition_list = []
         for p in range(num_partitions):
-            part_file = f"{accession_mapping_file}-{p}"
+            part_file = f"{os.path.basename(accession_mapping_file)}-{p}"
             partition_list.append(part_file)
             grab_accession_mapping_list_args.append([
                 accession_mapping_file,

--- a/index-generation/index_generation.wdl
+++ b/index-generation/index_generation.wdl
@@ -82,7 +82,7 @@ workflow index_generation {
     scatter (nr_chunk in ChunkNR.nr_chunks) {
         call GenerateIndexDiamondChunk {
             input:
-            nr = DownloadNR.nr,
+            nr = nr_chunk,
             docker_image_id = docker_image_id
         }
     }

--- a/index-generation/index_generation.wdl
+++ b/index-generation/index_generation.wdl
@@ -214,9 +214,7 @@ task GenerateIndexAccessions {
             --nt_file ~{nt} \
             --nr_file ~{nr} \
             --output_gz accession2taxid.gz \
-            --output_wgs_gz accession2taxid_wgs.gz \
             --accession2taxid_db accession2taxid.db \
-            --taxid2wgs_accession_db taxid2wgs_accession.db
     >>>
 
     output {

--- a/index-generation/index_generation.wdl
+++ b/index-generation/index_generation.wdl
@@ -82,7 +82,7 @@ workflow index_generation {
     scatter (nr_chunk in ChunkNR.nr_chunks) {
         call GenerateIndexDiamondChunk {
             input:
-            nr = nr_chunk,
+            nr_chunk = nr_chunk,
             docker_image_id = docker_image_id
         }
     }

--- a/index-generation/index_generation.wdl
+++ b/index-generation/index_generation.wdl
@@ -297,7 +297,7 @@ task GenerateIndexDiamondChunk {
         chunk_number="${chunk_path##*_}"
         # Ignore warning is needed because sometimes NR has sequences of only DNA characters which causes this to fail
         diamond makedb --ignore-warnings --in ~{nr_chunk} -d dir --scatter-gather -b $(cat ~{nr_chunk} | grep '^>' | wc -l)
-        mv "dir/*" "diamond_index_part_${chunk_number}"
+        mv dir/* "diamond_index_part_${chunk_number}"
     >>>
 
     output {
@@ -327,9 +327,9 @@ task GenerateIndexLineages {
         python3 /usr/local/bin/ncbitax2lin.py \
             --nodes-file taxdump/taxdump/nodes.dmp \
             --names-file taxdump/taxdump/names.dmp \
-            --names-output-prefix names.csv.gz \
-            --taxid-lineages-output-prefix taxid-lineages.csv.gz \
-            --name-lineages-output-prefix lineages.csv.gz
+            --names-output-prefix names \
+            --taxid-lineages-output-prefix taxid-lineages \
+            --name-lineages-output-prefix lineages
 
         # Add names to lineages
 
@@ -357,13 +357,13 @@ task GenerateIndexLineages {
     >>>
 
     output {
-        File taxid_lineages_db = "ncbitax2lin/taxid-lineages.db"
-        File taxid_lineages_csv = "ncbitax2lin/taxid-lineages.csv.gz"
-        File names_csv = "ncbitax2lin/names.csv.gz"
-        File named_taxid_lineages_csv = "ncbitax2lin/named-taxid-lineages.csv.gz"
-        File versioned_taxid_lineages_csv = "ncbitax2lin/versioned-taxid-lineages.csv.gz"
-        File deuterostome_taxids = "ncbitax2lin/deuterostome_taxids.txt"
-        File taxon_ignore_list = "ncbitax2lin/taxon_ignore_list.txt"
+        File taxid_lineages_db = "taxid-lineages.db"
+        File taxid_lineages_csv = "taxid-lineages.csv.gz"
+        File names_csv = "names.csv.gz"
+        File named_taxid_lineages_csv = "named-taxid-lineages.csv.gz"
+        File versioned_taxid_lineages_csv = "versioned-taxid-lineages.csv.gz"
+        File deuterostome_taxids = "deuterostome_taxids.txt"
+        File taxon_ignore_list = "taxon_ignore_list.txt"
     }
 
     runtime {

--- a/index-generation/index_generation.wdl
+++ b/index-generation/index_generation.wdl
@@ -324,7 +324,7 @@ task GenerateIndexLineages {
         mkdir -p taxdump/taxdump
         tar xf ~{taxdump} -C ./taxdump/taxdump
 
-        python3 ncbitax2lin.py \
+        python3 /usr/local/bin/ncbitax2lin.py \
             --nodes-file taxdump/taxdump/nodes.dmp \
             --names-file taxdump/taxdump/names.dmp \
             --names-output-prefix names.csv.gz \

--- a/index-generation/index_generation.wdl
+++ b/index-generation/index_generation.wdl
@@ -118,11 +118,10 @@ task DownloadNR {
 
     command <<<
         ncbi_download "~{ncbi_server}" blast/db/FASTA/nr.gz
-        pigz -dc blast/db/FASTA/nr.gz > nr
     >>>
 
     output {
-        File nr = "nr"
+        File nr = "blast/db/FASTA/nr"
     }
 
     runtime {
@@ -138,12 +137,11 @@ task DownloadNT {
 
     command <<<
         ncbi_download "~{ncbi_server}" blast/db/FASTA/nt.gz
-        pigz -dc blast/db/FASTA/nt.gz > nt
         
     >>>
 
     output {
-        File nt = "nt"
+        File nt = "blast/db/FASTA/nt"
     }
 
     runtime {
@@ -184,7 +182,7 @@ task DownloadTaxdump {
     >>>
 
     output {
-        File taxdump = "pub/taxonomy/taxdump.tar.gz"
+        File taxdump = "pub/taxonomy/taxdump.tar"
     }
 
     runtime {
@@ -206,10 +204,10 @@ task GenerateIndexAccessions {
 
         # Build index
         python3 /usr/local/bin/generate_accession2taxid.py \
-            ~{accession2taxid}/nucl_wgs.accession2taxid.gz \
-            ~{accession2taxid}/nucl_gb.accession2taxid.gz \
-            ~{accession2taxid}/pdb.accession2taxid.gz \
-            ~{accession2taxid}/prot.accession2taxid.FULL.gz \
+            ~{accession2taxid}/nucl_wgs.accession2taxid \
+            ~{accession2taxid}/nucl_gb.accession2taxid \
+            ~{accession2taxid}/pdb.accession2taxid \
+            ~{accession2taxid}/prot.accession2taxid.FULL \
             --parallelism ~{parallelism} \
             --nt_file ~{nt} \
             --nr_file ~{nr} \

--- a/index-generation/index_generation.wdl
+++ b/index-generation/index_generation.wdl
@@ -334,11 +334,15 @@ task GenerateIndexLineages {
         set -euxo pipefail
 
         # Build Indexes
-        git clone https://github.com/chanzuckerberg/ncbitax2lin.git
-        cd ncbitax2lin
         mkdir -p taxdump/taxdump
         tar zxf ~{taxdump} -C ./taxdump/taxdump
-        make 1>&2
+
+        python3 ncbitax2lin.py \
+            --nodes-file taxdump/taxdump/nodes.dmp \
+            --names-file taxdump/taxdump/names.dmp \
+            --names-output-prefix names.csv.gz \
+            --taxid-lineages-output-prefix taxid-lineages.csv.gz \
+            --name-lineages-output-prefix lineages.csv.gz
 
         # Add names to lineages
 

--- a/index-generation/index_generation.wdl
+++ b/index-generation/index_generation.wdl
@@ -362,7 +362,7 @@ task ChunkNT {
     >>>
 
     output {
-        Array[File] nt_chunks = "nt.split/*"
+        Array[File] nt_chunks = glob("nt.split/*")
     }
 
     runtime {
@@ -388,7 +388,7 @@ task GenerateIndexMinimap2Chunk {
     >>>
 
     output {
-        File minimap2_index = "nt.part_*.idx"
+        File minimap2_index = glob("nt.part_*.idx")[0]
     }
 
     runtime {

--- a/index-generation/index_generation.wdl
+++ b/index-generation/index_generation.wdl
@@ -291,7 +291,7 @@ task ChunkNR {
     >>>
 
     output {
-        Array[File] nt_chunks = glob("nr.split/*")
+        Array[File] nr_chunks = glob("nr.split/*")
     }
 
     runtime {

--- a/index-generation/index_generation.wdl
+++ b/index-generation/index_generation.wdl
@@ -75,7 +75,6 @@ workflow index_generation {
     output {
         File nr = DownloadNR.nr
         File nt = DownloadNT.nt
-        File accession2taxid_gz = GenerateIndexAccessions.accession2taxid_gz
         File accession2taxid_db = GenerateIndexAccessions.accession2taxid_db
         File nt_loc_db = GenerateNTDB.nt_loc_db
         File nt_info_db = GenerateNTDB.nt_info_db

--- a/index-generation/index_generation.wdl
+++ b/index-generation/index_generation.wdl
@@ -300,8 +300,8 @@ task GenerateIndexDiamondChunk {
         chunk_path="~{nr_chunk}"
         chunk_number="${chunk_path##*_}"
         # Ignore warning is needed because sometimes NR has sequences of only DNA characters which causes this to fail
-        diamond makedb --ignore-warnings --in ~{nr_chunk} -d "diamond_index_part_${chunk_number}" --scatter-gather -b $(cat ~{nr_chunk} | grep '^>' | wc -l)
-        mv "diamond_index_part_${chunk_number}_*" "diamond_index_part_${chunk_number}"
+        diamond makedb --ignore-warnings --in ~{nr_chunk} -d dir --scatter-gather -b $(cat ~{nr_chunk} | grep '^>' | wc -l)
+        mv "dir/*" "diamond_index_part_${chunk_number}"
     >>>
 
     output {
@@ -326,7 +326,7 @@ task GenerateIndexLineages {
 
         # Build Indexes
         mkdir -p taxdump/taxdump
-        tar zxf ~{taxdump} -C ./taxdump/taxdump
+        tar xf ~{taxdump} -C ./taxdump/taxdump
 
         python3 ncbitax2lin.py \
             --nodes-file taxdump/taxdump/nodes.dmp \

--- a/index-generation/index_generation.wdl
+++ b/index-generation/index_generation.wdl
@@ -296,8 +296,7 @@ task GenerateIndexDiamondChunk {
         chunk_path="~{nr_chunk}"
         chunk_number="${chunk_path##*_}"
         # Ignore warning is needed because sometimes NR has sequences of only DNA characters which causes this to fail
-        diamond makedb --ignore-warnings --in ~{nr_chunk} -d dir --scatter-gather -b $(cat ~{nr_chunk} | grep '^>' | wc -l)
-        mv dir/* "diamond_index_part_${chunk_number}"
+        diamond makedb --ignore-warnings --in ~{nr_chunk} -d "diamond_index_part_${chunk_number}"
     >>>
 
     output {

--- a/index-generation/index_generation.wdl
+++ b/index-generation/index_generation.wdl
@@ -65,10 +65,18 @@ workflow index_generation {
         docker_image_id = docker_image_id
     }
 
-    call GenerateIndexMinimap2 {
+    call ChunkNT {
         input:
         nt = DownloadNT.nt,
         docker_image_id = docker_image_id
+    }
+
+    scatter (nt_chunk in ChunkNT.nt_chunks) {
+        call GenerateIndexMinimap2Chunk {
+            input:
+            nt_chunk = nt_chunk,
+            docker_image_id = docker_image_id
+        }
     }
 
     output {
@@ -92,7 +100,7 @@ workflow index_generation {
         File versioned_taxid_lineages_csv = GenerateIndexLineages.versioned_taxid_lineages_csv
         File deuterostome_taxids = GenerateIndexLineages.deuterostome_taxids
         File taxon_ignore_list = GenerateIndexLineages.taxon_ignore_list
-        Directory minimap2_index = GenerateIndexMinimap2.minimap2_index
+        Array[File] minimap2_index = GenerateIndexMinimap2Chunk.minimap2_index
     }
 }
 
@@ -342,37 +350,45 @@ task GenerateIndexLineages {
     }
 }
 
-task GenerateIndexMinimap2 {
+task ChunkNT {
     input {
         File nt
-        Int k = 14 # Minimizer k-mer length default is 21 for short reads option
-        Int w = 8 # Minimizer window size default is 11 for short reads option
-        String I = "9999G" # Load at most NUM target bases into RAM for indexing
-        Int t = 20 # number of threads, doesn't really work for indexing I don't think
         Int n_chunks = 20
         String docker_image_id
     }
 
     command <<<
-        set -euxo pipefail
-
-        # Split nt into 20
         seqkit split2 ~{nt} -p ~{n_chunks} --out-dir nt.split
-
-        # Make output directory
-        OUTDIR="nt_k~{k}_w~{w}_~{n_chunks}"
-        mkdir $OUTDIR
-
-        # Run minimap2 on each chunk
-        for i in nt.split/*
-        do
-                path="${i##*_}"
-                minimap2 -cx sr -k ~{k} -w ~{w} -I ~{I} -t ~{t} -d $OUTDIR/"nt.part_"$path".idx" $i
-        done
     >>>
 
     output {
-        Directory minimap2_index = "nt_k~{k}_w~{w}_~{n_chunks}"
+        Array[File] nt_chunks = "nt.split/*"
+    }
+
+    runtime {
+        docker: docker_image_id
+    }
+}
+
+task GenerateIndexMinimap2Chunk {
+    input {
+        File nt_chunk
+        Int k = 14 # Minimizer k-mer length default is 21 for short reads option
+        Int w = 8 # Minimizer window size default is 11 for short reads option
+        String I = "9999G" # Load at most NUM target bases into RAM for indexing
+        Int t = 20 # number of threads, doesn't really work for indexing I don't think
+        String docker_image_id
+    }
+
+    command <<<
+        set -euxo pipefail
+        chunk_path="~{nt_chunk}"
+        chunk_number="${chunk_path##*_}"
+        minimap2 -cx sr -k ~{k} -w ~{w} -I ~{I} -t ~{t} -d "nt.part_"$chunk_number".idx" ~{nt_chunk}
+    >>>
+
+    output {
+        File minimap2_index = "nt.part_*.idx"
     }
 
     runtime {

--- a/index-generation/index_generation.wdl
+++ b/index-generation/index_generation.wdl
@@ -71,11 +71,10 @@ workflow index_generation {
         docker_image_id = docker_image_id
     }
 
+    # only include an output if it is confirmed that it is used elsewhere
     output {
         File nr = DownloadNR.nr
         File nt = DownloadNT.nt
-        Directory accession2taxid = DownloadAccession2Taxid.accession2taxid
-        File taxdump = DownloadTaxdump.taxdump
         File accession2taxid_gz = GenerateIndexAccessions.accession2taxid_gz
         File accession2taxid_db = GenerateIndexAccessions.accession2taxid_db
         File nt_loc_db = GenerateNTDB.nt_loc_db
@@ -84,9 +83,6 @@ workflow index_generation {
         File nr_info_db = GenerateNRDB.nr_info_db
         Directory diamond_index = GenerateIndexDiamond.diamond_index
         File taxid_lineages_db = GenerateIndexLineages.taxid_lineages_db
-        File taxid_lineages_csv = GenerateIndexLineages.taxid_lineages_csv
-        File names_csv = GenerateIndexLineages.names_csv
-        File named_taxid_lineages_csv = GenerateIndexLineages.named_taxid_lineages_csv
         File versioned_taxid_lineages_csv = GenerateIndexLineages.versioned_taxid_lineages_csv
         File deuterostome_taxids = GenerateIndexLineages.deuterostome_taxids
         File taxon_ignore_list = GenerateIndexLineages.taxon_ignore_list
@@ -195,12 +191,10 @@ task GenerateIndexAccessions {
             --parallelism ~{parallelism} \
             --nt_file ~{nt} \
             --nr_file ~{nr} \
-            --output_gz accession2taxid.gz \
             --accession2taxid_db accession2taxid.db \
     >>>
 
     output {
-        File accession2taxid_gz = "accession2taxid.gz"
         File accession2taxid_db = "accession2taxid.db"
     }
 
@@ -319,9 +313,6 @@ task GenerateIndexLineages {
 
     output {
         File taxid_lineages_db = "taxid-lineages.db"
-        File taxid_lineages_csv = "taxid-lineages.csv.gz"
-        File names_csv = "names.csv.gz"
-        File named_taxid_lineages_csv = "named-taxid-lineages.csv.gz"
         File versioned_taxid_lineages_csv = "versioned-taxid-lineages.csv.gz"
         File deuterostome_taxids = "deuterostome_taxids.txt"
         File taxon_ignore_list = "taxon_ignore_list.txt"

--- a/index-generation/index_generation.wdl
+++ b/index-generation/index_generation.wdl
@@ -310,7 +310,7 @@ task GenerateIndexDiamondChunk {
         chunk_path="~{nr_chunk}"
         chunk_number="${chunk_path##*_}"
         # Ignore warning is needed because sometimes NR has sequences of only DNA characters which causes this to fail
-        diamond makedb --ignore-warnings --in ~{nr_chunk} --db "diamond_index_part_${chunk_number}"
+        diamond makedb --ignore-warnings --in ~{nr_chunk} --db "diamond_index_part_${chunk_number}" -b $(cat ~{nr_chunk} | grep '^>' | wc -l)
     >>>
 
     output {

--- a/index-generation/ncbi_download
+++ b/index-generation/ncbi_download
@@ -12,3 +12,5 @@ if [[ $(md5sum $DOWNLOAD_PATH | cut -f 1 -d' ') != $(cat $DOWNLOAD_PATH.md5 | se
 then
     exit 1
 fi
+
+pigz -d $DOWNLOAD_PATH

--- a/index-generation/ncbi_download
+++ b/index-generation/ncbi_download
@@ -5,7 +5,7 @@ NCBI_SERVER=$1
 DOWNLOAD_PATH=$2
 
 mkdir -p $(dirname $DOWNLOAD_PATH)
-wget -P $(dirname $DOWNLOAD_PATH) -cnv $NCBI_SERVER/$DOWNLOAD_PATH
+aria2c -x 16 -o $DOWNLOAD_PATH $NCBI_SERVER/$DOWNLOAD_PATH
 wget -P $(dirname $DOWNLOAD_PATH) -cnv $NCBI_SERVER/$DOWNLOAD_PATH.md5
 
 if [[ $(md5sum $DOWNLOAD_PATH | cut -f 1 -d' ') != $(cat $DOWNLOAD_PATH.md5 | sed -e 's/^\s*//' | cut -f 1 -d' ') ]]

--- a/index-generation/ncbitax2lin.py
+++ b/index-generation/ncbitax2lin.py
@@ -1,0 +1,278 @@
+import re
+import os
+import gzip
+import multiprocessing
+import argparse
+import logging
+import shelve
+import pandas as pd
+
+from utils import timeit
+
+
+logging.basicConfig(
+    level=logging.DEBUG, format='%(asctime)s|%(levelname)s|%(message)s')
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=('This script converts NCBI taxonomy (taxdump) into '
+                     'lineages, save the information in csv.gz format'))
+
+    parser.add_argument(
+        '--nodes-file', required=True,
+        help='NCBI taxonomy path/to/taxdump/nodes.dmp')
+
+    parser.add_argument(
+        '--names-file', required=True,
+        help='NCBI taxonomy path/to/taxdump/names.dmp')
+
+    parser.add_argument(
+        '-o', '--output-prefix', default='ncbi_lineages',
+        help='will output lineage name information in [output_prefix].csv.gz')
+
+    parser.add_argument(
+        '--names-output-prefix', default='ncbi_names',
+        help='will output scientific-name information in [names_output_prefix].csv.gz')
+
+    parser.add_argument(
+        '--taxid-lineages-output-prefix', default='ncbi_taxid_lineages',
+        help='will output lineage taxon-ID information in [taxid_lineages_output_prefix].csv.gz')
+
+    parser.add_argument(
+        '--name-lineages-output-prefix', default='ncbi_name_lineages',
+        help='will output lineage name information in [name_lineages_output_prefix].csv.gz')
+
+    args = parser.parse_args()
+    return args
+
+
+def strip(str_):
+    '''
+    :param str_: a string
+    '''
+    return str_.strip()
+
+
+@timeit
+def load_nodes(nodes_file):
+    '''
+    load nodes.dmp and convert it into a pandas.DataFrame
+    '''
+    df = pd.read_csv(nodes_file, sep='|', header=None, index_col=False,
+                     names=[
+                         'tax_id',
+                         'parent_tax_id',
+                         'rank',
+                         'embl_code',
+                         'division_id',
+                         'inherited_div_flag',
+                         'genetic_code_id',
+                         'inherited_GC__flag',
+                         'mitochondrial_genetic_code_id',
+                         'inherited_MGC_flag',
+                         'GenBank_hidden_flag',
+                         'hidden_subtree_root_flag',
+                         'comments'
+                     ])
+
+    # To get rid of flanking tab characters
+    df['rank'] = df['rank'].apply(strip)
+    df['embl_code'] = df['embl_code'].apply(strip)
+    df['comments'] = df['comments'].apply(strip)
+    return df
+
+
+@timeit
+def load_names(names_file, name_class='scientific name'):
+    '''
+    load names.dmp and convert it into a pandas.DataFrame
+    '''
+    df = pd.read_csv(names_file, sep='|', header=None, index_col=False,
+                     names=[
+                         'tax_id',
+                         'name_txt',
+                         'unique_name',
+                         'name_class'
+                     ])
+    df['name_txt'] = df['name_txt'].apply(strip)
+    df['unique_name'] = df['unique_name'].apply(strip)
+    df['name_class'] = df['name_class'].apply(strip)
+
+    sci_df = df[df['name_class'] == name_class]
+    sci_df.reset_index(drop=True, inplace=True)
+    return sci_df
+
+
+def to_name_dict(lineage):
+    """
+    convert the lineage from a list of tuples in the form of
+    [
+        (tax_id1, rank1, name_txt1),
+        (tax_id2, rank2, name_txt2),
+        ...
+    ]
+    to a dictionary of taxon names
+    """
+    dd = {}
+    num_re = re.compile('[0-9]+')
+    len_lineage = len(lineage)
+    for k, __ in enumerate(lineage):
+        tax_id, rank, name_txt = __
+        # use the last rank as the tax_id, whatever it is, genus or species.
+        if k == len_lineage - 1:
+            dd['tax_id'] = tax_id
+
+        # e.g. there could be multiple 'no rank'
+        numbered_rank = rank
+        while numbered_rank in dd:
+            search = num_re.search(numbered_rank)
+            if search is None:
+                count = 1
+            else:
+                count = int(search.group()) + 1
+            numbered_rank = '{0}{1}'.format(rank, count)
+        dd[numbered_rank] = name_txt
+    return dd
+
+def to_taxid_dict(lineage):
+    """
+    convert the lineage from a list of tuples in the form of
+    [
+        (tax_id1, rank1, name_txt1),
+        (tax_id2, rank2, name_txt2),
+        ...
+    ]
+    to a dictionary of taxids
+    """
+    dd = {}
+    num_re = re.compile('[0-9]+')
+    len_lineage = len(lineage)
+    for k, __ in enumerate(lineage):
+        tax_id, rank, name_txt = __
+        # use the last rank as the tax_id, whatever it is, genus or species.
+        if k == len_lineage - 1:
+            dd['tax_id'] = int(tax_id)
+
+        # e.g. there could be multiple 'no rank'
+        numbered_rank = rank
+        while numbered_rank in dd:
+            search = num_re.search(numbered_rank)
+            if search is None:
+                count = 1
+            else:
+                count = int(search.group()) + 1
+            numbered_rank = '{0}{1}'.format(rank, count)
+        dd[numbered_rank] = int(tax_id)
+    return dd
+
+def find_lineage(tax_id):
+    if tax_id % 50000 == 0:
+        logging.debug('working on tax_id: {0}'.format(tax_id))
+    lineage = []
+    while True:
+        rec = TAXONOMY_DICT[tax_id]
+        lineage.append((rec['tax_id'], rec['rank'], rec['name_txt']))
+        tax_id = rec['parent_tax_id']
+
+        if tax_id == 1:
+            break
+
+    # reverse results in lineage of Kingdom => species, this is helpful for
+    # to_dict when there are multiple "no rank"s
+    lineage.reverse()
+    return to_name_dict(lineage), to_taxid_dict(lineage)
+
+def process_lineage_dd(lineage_dd):
+    dd_for_df = dict(zip(range(len(lineage_dd)), lineage_dd))
+    lineages_df = pd.DataFrame.from_dict(dd_for_df, orient='index')
+    return lineages_df.sort_values('tax_id')
+
+def write_output(output_prefix, output_name_log, df, cols=None, undef_taxids=None):
+    output = os.path.join('{0}.csv.gz'.format(output_prefix))
+    logging.info("writing %s to %s" % (output_name_log, output))
+    with open(output, 'wb') as opf:
+        # make sure the name and timestamp are not gzipped, (like gzip -n)
+        opf_gz = gzip.GzipFile('', 'wb', 9, opf, 0.)
+        if undef_taxids and cols:
+            for col in undef_taxids.keys():
+                df[[col]] = df[[col]].fillna(value=undef_taxids[col])
+            # filling remaing na values as 0
+            df[cols] = df[cols].fillna(0)
+            df[cols] = df[cols].astype(int)
+        if cols:
+            df.to_csv(opf_gz, index=False, columns=cols)
+        else:
+            df.to_csv(opf_gz, index=False)
+        opf_gz.close()
+
+def generate_name_output(nodes_df, names_file, name_class):
+    names_df = load_names(names_file, name_class)
+    df = nodes_df.merge(names_df, on='tax_id')
+    df = df[['tax_id', 'parent_tax_id', 'rank', 'name_txt']]
+    df.reset_index(drop=True, inplace=True)
+    logging.info('# of tax ids: {0}'.format(df.shape[0]))
+    df.info()
+    return df
+
+@timeit
+def generate_lineage_outputs(df, taxid_lineages_output_prefix, name_lineages_output_prefix):
+    global TAXONOMY_DICT # example item: (16, {'parent_tax_id': 32011, 'name_txt': 'Methylophilus', 'rank': 'genus', 'tax_id': 16})
+    logging.info('generating TAXONOMY_DICT...')
+    TAXONOMY_DICT = dict(zip(df.tax_id.values, df.to_dict('records')))
+
+    ncpus = multiprocessing.cpu_count()
+    logging.info('found {0} cpus, and will use all of them to find lineages '
+                 'for all tax ids'.format(ncpus))
+    pool = multiprocessing.Pool(ncpus)
+    name_lineages_dd, taxid_lineages_dd = zip(*pool.map(find_lineage, df.tax_id.values)) # take about 18G memory
+    pool.close()
+
+    logging.info('generating lineage-by-name output...')
+    name_lineages_df = process_lineage_dd(name_lineages_dd)
+    name_lineages_df.columns = name_lineages_df.columns.str.replace('no rank', 'no_rank')
+    write_output(name_lineages_output_prefix, "name lineages", name_lineages_df,
+                 ['tax_id', 'superkingdom', 'kingdom', 'phylum', 'class', 'order', 'family', 'genus', 'species'] +
+                 [col for col in name_lineages_df if col.startswith('no_rank')])
+
+    logging.info('generating lineage-by-taxid output...')
+    taxid_lineages_df = process_lineage_dd(taxid_lineages_dd)
+    taxid_lineages_df.columns = taxid_lineages_df.columns.str.replace(' ', '_')
+    undef_taxids = {'species': -100,
+                    'genus': -200,
+                    'family': -300,
+                    'order': -400,
+                    'class': -500,
+                    'phylum': -600,
+                    'kingdom': -650,
+                    'superkingdom': -700}
+    write_output(taxid_lineages_output_prefix, "taxid lineages", taxid_lineages_df,
+                 ['tax_id', 'superkingdom', 'kingdom', 'phylum', 'class', 'order', 'family', 'genus', 'species'] +
+                 [col for col in taxid_lineages_df if col.startswith('no_rank')],
+                 undef_taxids=undef_taxids)
+
+    logging.info('writing lineage-by-taxid shelf...')
+    taxid_lineages_shelf_output = os.path.join('{0}.db'.format(taxid_lineages_output_prefix))
+    d = shelve.open(taxid_lineages_shelf_output)
+    for _, row in taxid_lineages_df.iterrows():
+        d[str(int(row['tax_id']))] = (str(int(row['species'])), str(int(row['genus'])), str(int(row['family'])))
+    d.close()
+
+def main():
+    args = parse_args()
+
+    logging.info('PART I: name outputs')
+    nodes_df = load_nodes(args.nodes_file)
+    logging.info(' * get scientific names')
+    scientific_df = generate_name_output(nodes_df, args.names_file, 'scientific name')
+    logging.info(' * get common names')
+    common_df = generate_name_output(nodes_df, args.names_file, 'genbank common name')
+    logging.info(' * merge names')
+    df = scientific_df.merge(common_df, 'left', on='tax_id', suffixes=('', '_common'))
+    write_output(args.names_output_prefix, "names", df, ['tax_id', 'name_txt', 'name_txt_common'])
+
+    logging.info('PART II: lineage and scientific name outputs')
+    generate_lineage_outputs(scientific_df, args.taxid_lineages_output_prefix, args.name_lineages_output_prefix)
+
+if __name__ == "__main__":
+    main()

--- a/index-generation/ncbitax2lin.py
+++ b/index-generation/ncbitax2lin.py
@@ -135,6 +135,7 @@ def to_name_dict(lineage):
         dd[numbered_rank] = name_txt
     return dd
 
+
 def to_taxid_dict(lineage):
     """
     convert the lineage from a list of tuples in the form of
@@ -166,6 +167,7 @@ def to_taxid_dict(lineage):
         dd[numbered_rank] = int(tax_id)
     return dd
 
+
 def find_lineage(tax_id):
     if tax_id % 50000 == 0:
         logging.debug('working on tax_id: {0}'.format(tax_id))
@@ -183,10 +185,12 @@ def find_lineage(tax_id):
     lineage.reverse()
     return to_name_dict(lineage), to_taxid_dict(lineage)
 
+
 def process_lineage_dd(lineage_dd):
     dd_for_df = dict(zip(range(len(lineage_dd)), lineage_dd))
     lineages_df = pd.DataFrame.from_dict(dd_for_df, orient='index')
     return lineages_df.sort_values('tax_id')
+
 
 def write_output(output_prefix, output_name_log, df, cols=None, undef_taxids=None):
     output = os.path.join('{0}.csv.gz'.format(output_prefix))
@@ -206,6 +210,7 @@ def write_output(output_prefix, output_name_log, df, cols=None, undef_taxids=Non
             df.to_csv(opf_gz, index=False)
         opf_gz.close()
 
+
 def generate_name_output(nodes_df, names_file, name_class):
     names_df = load_names(names_file, name_class)
     df = nodes_df.merge(names_df, on='tax_id')
@@ -215,9 +220,11 @@ def generate_name_output(nodes_df, names_file, name_class):
     df.info()
     return df
 
+
 @timeit
 def generate_lineage_outputs(df, taxid_lineages_output_prefix, name_lineages_output_prefix):
-    global TAXONOMY_DICT # example item: (16, {'parent_tax_id': 32011, 'name_txt': 'Methylophilus', 'rank': 'genus', 'tax_id': 16})
+    # example item: (16, {'parent_tax_id': 32011, 'name_txt': 'Methylophilus', 'rank': 'genus', 'tax_id': 16})
+    global TAXONOMY_DICT
     logging.info('generating TAXONOMY_DICT...')
     TAXONOMY_DICT = dict(zip(df.tax_id.values, df.to_dict('records')))
 
@@ -225,7 +232,7 @@ def generate_lineage_outputs(df, taxid_lineages_output_prefix, name_lineages_out
     logging.info('found {0} cpus, and will use all of them to find lineages '
                  'for all tax ids'.format(ncpus))
     pool = multiprocessing.Pool(ncpus)
-    name_lineages_dd, taxid_lineages_dd = zip(*pool.map(find_lineage, df.tax_id.values)) # take about 18G memory
+    name_lineages_dd, taxid_lineages_dd = zip(*pool.map(find_lineage, df.tax_id.values))  # take about 18G memory
     pool.close()
 
     logging.info('generating lineage-by-name output...')
@@ -258,6 +265,7 @@ def generate_lineage_outputs(df, taxid_lineages_output_prefix, name_lineages_out
         d[str(int(row['tax_id']))] = (str(int(row['species'])), str(int(row['genus'])), str(int(row['family'])))
     d.close()
 
+
 def main():
     args = parse_args()
 
@@ -273,6 +281,7 @@ def main():
 
     logging.info('PART II: lineage and scientific name outputs')
     generate_lineage_outputs(scientific_df, args.taxid_lineages_output_prefix, args.name_lineages_output_prefix)
+
 
 if __name__ == "__main__":
     main()

--- a/index-generation/ncbitax2lin.py
+++ b/index-generation/ncbitax2lin.py
@@ -1,17 +1,62 @@
-import re
-import os
-import gzip
-import multiprocessing
 import argparse
+import datetime
+import gzip
 import logging
+import multiprocessing
+import os
+import re
 import shelve
-import pandas as pd
+import time
+from functools import update_wrapper
 
-from utils import timeit
+import pandas as pd
 
 
 logging.basicConfig(
     level=logging.DEBUG, format='%(asctime)s|%(levelname)s|%(message)s')
+
+
+def decorator(d):
+    "Make function d a decorator: d wraps a function fn."
+    def _d(fn):
+        return update_wrapper(d(fn), fn)
+    update_wrapper(_d, d)
+    return _d
+
+
+@decorator
+def timeit(f):
+    """time a function, used as decorator"""
+    def new_f(*args, **kwargs):
+        bt = time.time()
+        r = f(*args, **kwargs)
+        et = time.time()
+        delta_t = datetime.timedelta(seconds=(et - bt))
+        logging.info("Time spent on {0}: {1}".format(f.__name__, delta_t))
+        return r
+    return new_f
+
+
+def backup_file(f):
+    """
+    Back up a file, old_file will be renamed to #old_file.n#, where n is a
+    number incremented each time a backup takes place
+    """
+    if os.path.exists(f):
+        dirname = os.path.dirname(f)
+        basename = os.path.basename(f)
+        count = 1
+        rn_to = os.path.join(
+            dirname, '#' + basename + '.{0}#'.format(count))
+        while os.path.exists(rn_to):
+            count += 1
+            rn_to = os.path.join(
+                dirname, '#' + basename + '.{0}#'.format(count))
+        logging.info("Backing up {0} to {1}".format(f, rn_to))
+        os.rename(f, rn_to)
+        return rn_to
+    else:
+        logging.warning('{0} doesn\'t exist'.format(f))
 
 
 def parse_args():


### PR DESCRIPTION
This is a sort of kitchen sink of improvements to index generation:
- Switch to using pigz for un-gzipping all of our downloads. Our python scripts were doing some uinzipping, this should be WAY slower than pigz, which unzips in parallel.
- Switch to downloading with aria2 instead of wget. Aria is a multiplexed downloader that can download over http and ftp. With aria2 we can establish multiple connections with the ncbi server and download much much faster.
- Eliminate needless steps from generating accessions. We are currently outputting these wgs index files that we don't use anywhere. I removed them.
- Remove needless downloads for generating accessions. We were downloading files that were not used for generating the accession index.
- ~~Use scatter gather for generating alignment indexes.~~
- Encorporate ncbi tax 2 lin into this repo and upgrade to python3