### PR TITLE
downgrade ubuntu version for short-read-mngs compat

### DIFF
--- a/index-generation/Dockerfile
+++ b/index-generation/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:18.04
 ARG DEBIAN_FRONTEND=noninteractive
 ARG ARIA2_VERSION=1.36.0
 

--- a/index-generation/Dockerfile
+++ b/index-generation/Dockerfile
@@ -1,3 +1,4 @@
+## TODO: upgrade to 22.04 once we replace shelve
 FROM ubuntu:18.04
 ARG DEBIAN_FRONTEND=noninteractive
 ARG ARIA2_VERSION=1.36.0
@@ -9,7 +10,8 @@ RUN apt-get update && \
         ## diamond
         g++ \
         gdb \
-        libclang-common-12-dev \
+        libclang-common-6.0-dev \
+        # libclang-common-12-dev \
         cmake\
         g++\
         zlib1g-dev \

--- a/index-generation/ncbitax2lin.py
+++ b/index-generation/ncbitax2lin.py
@@ -1,6 +1,5 @@
 import argparse
 import datetime
-import gzip
 import logging
 import multiprocessing
 import os

--- a/index-generation/ncbitax2lin.py
+++ b/index-generation/ncbitax2lin.py
@@ -240,20 +240,13 @@ def process_lineage_dd(lineage_dd):
 def write_output(output_prefix, output_name_log, df, cols=None, undef_taxids=None):
     output = os.path.join('{0}.csv.gz'.format(output_prefix))
     logging.info("writing %s to %s" % (output_name_log, output))
-    with open(output, 'wb') as opf:
-        # make sure the name and timestamp are not gzipped, (like gzip -n)
-        opf_gz = gzip.GzipFile('', 'w', 9, opf, 0.)
-        if undef_taxids and cols:
-            for col in undef_taxids.keys():
-                df[[col]] = df[[col]].fillna(value=undef_taxids[col])
-            # filling remaing na values as 0
-            df[cols] = df[cols].fillna(0)
-            df[cols] = df[cols].astype(int)
-        if cols:
-            df.to_csv(opf_gz, index=False, columns=cols)
-        else:
-            df.to_csv(opf_gz, index=False)
-        opf_gz.close()
+    if undef_taxids and cols:
+        for col in undef_taxids.keys():
+            df[[col]] = df[[col]].fillna(value=undef_taxids[col])
+        # filling remaing na values as 0
+        df[cols] = df[cols].fillna(0)
+        df[cols] = df[cols].astype(int)
+    df.to_csv(output, index=False, columns=cols, compression='gzip')
 
 
 def generate_name_output(nodes_df, names_file, name_class):

--- a/index-generation/ncbitax2lin.py
+++ b/index-generation/ncbitax2lin.py
@@ -242,7 +242,7 @@ def write_output(output_prefix, output_name_log, df, cols=None, undef_taxids=Non
     logging.info("writing %s to %s" % (output_name_log, output))
     with open(output, 'wb') as opf:
         # make sure the name and timestamp are not gzipped, (like gzip -n)
-        opf_gz = gzip.GzipFile('', 'wb', 9, opf, 0.)
+        opf_gz = gzip.GzipFile('', 'w', 9, opf, 0.)
         if undef_taxids and cols:
             for col in undef_taxids.keys():
                 df[[col]] = df[[col]].fillna(value=undef_taxids[col])


### PR DESCRIPTION
short-read-mngs is unable to use the shelve version that ships with the newer version of python. I tried to upgrade short-read-mngs but it will be a major project so I am downgrading this to the same version. Once we replace shelve we can upgrade this again.