### PR TITLE
Append closing paren to generate coverage stats instead of write

### DIFF
--- a/short-read-mngs/idseq-dag/idseq_dag/steps/generate_coverage_stats.py
+++ b/short-read-mngs/idseq-dag/idseq_dag/steps/generate_coverage_stats.py
@@ -179,7 +179,7 @@ class PipelineStepGenerateCoverageStats(PipelineStep):
         # if all intermediate json files are empty, close collated json file
         json_sizes = sum(os.path.getsize(tfn) for tfn in output_json_filenames[:-1])
         if json_sizes == 0:
-            with open(output_json_filenames[-1], "w") as ojson:
+            with open(output_json_filenames[-1], "a") as ojson:
                 ojson.write("}")
         for tfn in output_json_filenames[:-1]:
             os.remove(tfn)


### PR DESCRIPTION
* I'm pretty sure writing overwrites the file including the opening parentheses