### PR TITLE
Fix phylotree missing accessions

### DIFF
--- a/phylotree-ng/run.wdl
+++ b/phylotree-ng/run.wdl
@@ -138,6 +138,9 @@ task GetReferenceAccessionFastas {
         nt = marisa_trie.RecordTrie("QII").mmap('~{nt_loc_db}')
         nr = marisa_trie.RecordTrie("QII").mmap('~{nr_loc_db}')
         for accession_id in ["~{sep='", "' accession_ids}"]:
+            if not accession_id:
+                continue
+
             if accession_id in nt:
                 (seq_offset, header_len, seq_len), = nt[accession_id]
                 s3_path = '~{nt_s3_path}'

--- a/phylotree-ng/test/test_wdl.py
+++ b/phylotree-ng/test/test_wdl.py
@@ -8,9 +8,13 @@ from Bio.Phylo import NewickIO
 from test_util import WDLTestCase
 
 
-nt_s3_path = "s3://czid-public-references/ncbi-indexes-prod/2021-01-22/index-generation-2/nt"
+nt_s3_path = (
+    "s3://czid-public-references/ncbi-indexes-prod/2021-01-22/index-generation-2/nt"
+)
 nt_loc_db = "s3://czid-public-references/ncbi-indexes-prod/2021-01-22/index-generation-2/nt_loc.marisa"
-nr_s3_path = "s3://czid-public-references/ncbi-indexes-prod/2021-01-22/index-generation-2/nr"
+nr_s3_path = (
+    "s3://czid-public-references/ncbi-indexes-prod/2021-01-22/index-generation-2/nr"
+)
 nr_loc_db = "s3://czid-public-references/ncbi-indexes-prod/2021-01-22/index-generation-2/nr_loc.marisa"
 
 
@@ -22,10 +26,9 @@ class TestPhylotree(WDLTestCase):
     for i, name in enumerate(os.listdir(samples_dir)):
         first_dot = name.find(".")
         sample_name = name[:first_dot]
-        sample = samples.get(sample_name, {
-            "workflow_run_id": i,
-            "sample_name": sample_name,
-        })
+        sample = samples.get(
+            sample_name, {"workflow_run_id": i, "sample_name": sample_name}
+        )
         if "contig_summary" in name:
             sample["combined_contig_summary"] = os.path.join(samples_dir, name)
         else:
@@ -51,23 +54,31 @@ class TestPhylotree(WDLTestCase):
         res = self.run_miniwdl()
         outputs = res["outputs"]
 
-        self.assertCountEqual(outputs.keys(), [
-            "phylotree.clustermap_png",
-            "phylotree.clustermap_svg",
-            "phylotree.ncbi_metadata_json",
-            "phylotree.phylotree_newick",
-            "phylotree.ska_distances",
-            "phylotree.variants",
-        ])
+        self.assertCountEqual(
+            outputs.keys(),
+            [
+                "phylotree.clustermap_png",
+                "phylotree.clustermap_svg",
+                "phylotree.ncbi_metadata_json",
+                "phylotree.phylotree_newick",
+                "phylotree.ska_distances",
+                "phylotree.variants",
+            ],
+        )
 
         with open(outputs["phylotree.phylotree_newick"]) as f:
             tree = next(NewickIO.parse(f))
-            nodes = [n.name for n in tree.get_terminals() + tree.get_nonterminals() if n.name]
+            nodes = [
+                n.name for n in tree.get_terminals() + tree.get_nonterminals() if n.name
+            ]
             self.assertCountEqual(nodes, sample_names + self.accession_ids)
 
         identifiers = sorted(sample_names + self.accession_ids)
         with open(outputs["phylotree.ska_distances"]) as f:
-            pairs = [sorted([r["Sample 1"], r["Sample 2"]]) for r in DictReader(f, delimiter="\t")]
+            pairs = [
+                sorted([r["Sample 1"], r["Sample 2"]])
+                for r in DictReader(f, delimiter="\t")
+            ]
             expected = [[a, b] for a in identifiers for b in identifiers if a < b]
             self.assertCountEqual(pairs, expected)
 
@@ -75,19 +86,37 @@ class TestPhylotree(WDLTestCase):
             self.assertCountEqual(identifiers, [r.id for r in SeqIO.parse(f, "fasta")])
 
         with open(outputs["phylotree.ncbi_metadata_json"]) as f:
-            self.assertEqual(json.load(f), {
-                "NC_012532.1": {
-                    "name": "Zika virus, complete genome",
-                    "country": "Uganda",
+            self.assertEqual(
+                json.load(f),
+                {
+                    "NC_012532.1": {
+                        "name": "Zika virus, complete genome",
+                        "country": "Uganda",
+                    },
+                    "NC_035889.1": {
+                        "name": "Zika virus isolate ZIKV/H. sapiens/Brazil/Natal/2015, complete genome",
+                        "country": "Brazil: Rio Grande do Norte, Natal",
+                        "collection_date": "2015",
+                    },
                 },
-                "NC_035889.1": {
-                    "name": "Zika virus isolate ZIKV/H. sapiens/Brazil/Natal/2015, complete genome",
-                    "country": "Brazil: Rio Grande do Norte, Natal",
-                    "collection_date": "2015",
-                },
-            })
+            )
 
         with open(outputs["phylotree.clustermap_svg"]) as f:
             full_text = "\n".join(f.readlines())
             for name in sample_names + self.accession_ids:
                 self.assertEqual(full_text.count(name), 2, name)
+
+    def test_empty_accessions(self):
+        inputs = {
+            "nr_loc_db": nr_loc_db,
+            "nr_s3_path": nr_s3_path,
+            "nt_loc_db": nt_loc_db,
+            "nt_s3_path": nt_s3_path,
+            "accession_ids": [],
+        }
+        res = self.run_miniwdl(task="GetReferenceAccessionFastas", task_input=inputs)
+        outputs = res["outputs"]
+
+        self.assertEqual(
+            len(outputs["GetReferenceAccessionFastas.reference_fastas"]), 0
+        )


### PR DESCRIPTION
* This was tricky to see before running it, when phylotrees don't get an accession, they defaulted to an empty string 
* Also added a test, and ran `black` on phylotree test_wdl.py