### PR TITLE
escape prefix name

### DIFF
--- a/consensus-genome/run.wdl
+++ b/consensus-genome/run.wdl
@@ -1147,7 +1147,7 @@ task ZipOutputs {
 
         mkdir ${TMPDIR}/outputs
         cp ~{sep=' ' outputFiles} ${TMPDIR}/outputs/
-        zip -r -j ~{prefix}outputs.zip ${TMPDIR}/outputs/
+        zip -r -j "~{prefix}"outputs.zip ${TMPDIR}/outputs/
     >>>
 
     output {


### PR DESCRIPTION
* prefix names (which come from sample names) with special characters can cause the zip function to break
* we usually sanitize the filenames on the webapp now, but benchmark files and old files still contain these characters