### PR TITLE
refactor the full benchmark trigger to use czid name

### DIFF
--- a/.github/workflows/short-read-mngs-full-benchmarks.yml
+++ b/.github/workflows/short-read-mngs-full-benchmarks.yml
@@ -41,6 +41,6 @@ jobs:
       # WORKFLOW code specified in the user inputs.
       - name: Trigger benchmarks
         run: |
-          export DEPLOY_REF='${{github.event.inputs.czid_ref}}' GITHUB_TOKEN=${GH_DEPLOY_TOKEN:-GITHUB_TOKEN} IDSEQ_WORKFLOWS_RELEASE='${{github.event.inputs.czid_workflows_release}}' INDEX_VERSION='${{github.event.inputs.index_version}}'
-          workflow_args=$(jq -n ".ref=env.DEPLOY_REF | .inputs={idseq_workflows_release: env.IDSEQ_WORKFLOWS_RELEASE, index_version: env.INDEX_VERSION, idseq_workflows_ref: env.GITHUB_SHA}")
+          export DEPLOY_REF='${{github.event.inputs.czid_ref}}' GITHUB_TOKEN=${GH_DEPLOY_TOKEN:-GITHUB_TOKEN} CZID_WORKFLOWS_RELEASE='${{github.event.inputs.czid_workflows_release}}' INDEX_VERSION='${{github.event.inputs.index_version}}'
+          workflow_args=$(jq -n ".ref=env.DEPLOY_REF | .inputs={czid_workflows_release: env.CZID_WORKFLOWS_RELEASE, index_version: env.INDEX_VERSION, czid_workflows_ref: env.GITHUB_SHA}")
           gh api repos/:owner/idseq/actions/workflows/short-read-mngs-benchmarks.yml/dispatches --input - <<< "$workflow_args"


### PR DESCRIPTION
To be paired with https://github.com/chanzuckerberg/idseq/pull/446. Refactors the github actions input names to use czid instead of idseq.