### PR TITLE
run benchmarks simultaneously

### DIFF
--- a/short-read-mngs/auto_benchmark/run_dev.py
+++ b/short-read-mngs/auto_benchmark/run_dev.py
@@ -170,7 +170,7 @@ def run_sample(czid_repo, workflow_version, index_version, settings, key_prefix,
 
     # now the lock is released
     # this is a simplified version of some of the functionality of subprocess.run
-    
+
     # wait for the process to complete and get stdout and stderr
     stdout, stderr = process.communicate()
     # get the return code of the process

--- a/short-read-mngs/auto_benchmark/run_dev.py
+++ b/short-read-mngs/auto_benchmark/run_dev.py
@@ -160,16 +160,24 @@ def run_sample(czid_repo, workflow_version, index_version, settings, key_prefix,
         f" --sfn-input '{json.dumps(local_input)}'"
     ]
     print(cmd, file=sys.stderr)
-    # we don't want to have multiple invocations of run_sfn happen at the exact same time
-    #   so first, aquire the lock
+
+    # we don't want to have multiple invocations of run_sfn happen in the same second because
+    #   second-precision timestamps are used as unique identifiers by run_sfn, this locking
+    #   and waiting mechanism avoids this problem.
+
+    # First, aquire the lock
     with _timestamp_lock:
-        # wait a bit to ensure things are safe
+        # wait more than 1 second to ensure we don't start in the same second as the previous invocation
         time.sleep(1.1)
         # open the subprocess
         process = subprocess.Popen(cmd, cwd=czid_repo, stdout=sys.stderr.buffer)
 
-    # now the lock is released
-    # this is a simplified version of some of the functionality of subprocess.run
+    # release the lock
+
+    # below is a simplified version of some of the functionality of subprocess.run
+    #   we could not use subprocess.run because it starts the process and blocks until it
+    #   it completes and we need to start the process, then release the lock, then block
+    #   until the process completes
 
     # wait for the process to complete and get stdout and stderr
     stdout, stderr = process.communicate()
@@ -177,7 +185,7 @@ def run_sample(czid_repo, workflow_version, index_version, settings, key_prefix,
     retcode = process.poll()
     # if the return code is non zero then the process failed
     if retcode:
-        # raise a CalledProcessError with the process' return code and output
+        # raise a CalledProcessError with the process' return code and outputs
         raise subprocess.CalledProcessError(retcode, process.args, output=stdout, stderr=stderr)
 
     workflow_major_version = workflow_version.split(".")[0]


### PR DESCRIPTION
After further discussions with @mlin I think I finally got to the bottom of this. There was the element of controlling time tracking that he mentioned, but that didn't explain why the lock was called `_timestamp_lock` and why there was a 1.1 second wait time. 

What does explain it is that `run_sfn` uses second-precision timestamps as unique identifiers. This means you can't invoke `run_sfn` twice in the same second or you will get a name conflict. This explains the `_timestamp_lock` (it is a lock to guarantee unique timestamps) and the 1.1 second wait time (needs to be longer than a second to guarantee it will never be invoked within the same second.

This means this change actually is necessary now that we want to move towards concurrent runs for our benchmarks. I updated the comments with a detailed description of why this behavior is necessary and how it works and this is ready for review!

## Previous Description (preserved for historical context)

I am raising this as a draft PR to communicate what I am thinking here. This actually might not be necessary. From the looks of the code here (like the 1.1 second sleep) it appears the intent may have been to prevent `run_sfn` from being invoked at the same time by multiple threads. Alternatively, the intent really could have been to sequence them one after another. This seems odd to me because a lot of effort was put into parallelizing these in the first place, hence the source of confusion.

If the issue is preventing `run_sfn` from being invoked at the same time this will solve it. It starts the process, then releases the lock, then waits for the process to complete. All of this is happening inside of a future which handles the parallelism.

If the intent was running one at a time then we should close this PR and discuss why. If we want to keep it that way we can remove the futures stuff.