### PR TITLE
simplify running benchmarks

### DIFF
--- a/short-read-mngs/auto_benchmark/run_dev.py
+++ b/short-read-mngs/auto_benchmark/run_dev.py
@@ -15,8 +15,6 @@ import os
 import argparse
 import subprocess
 import concurrent.futures
-import threading
-import time
 import json
 import requests
 from datetime import datetime

--- a/short-read-mngs/auto_benchmark/run_dev.py
+++ b/short-read-mngs/auto_benchmark/run_dev.py
@@ -123,9 +123,6 @@ def run_samples(czid, samples, workflow_version, index_version, settings):
         raise failures[0][1]
 
 
-_timestamp_lock = threading.Lock()
-
-
 def run_sample(czid_repo, workflow_version, index_version, settings, key_prefix, sample):
     local_input = {
         **BENCHMARKS["settings"][settings],
@@ -161,32 +158,7 @@ def run_sample(czid_repo, workflow_version, index_version, settings, key_prefix,
     ]
     print(cmd, file=sys.stderr)
 
-    # we don't want to have multiple invocations of run_sfn happen in the same second because
-    #   second-precision timestamps are used as unique identifiers by run_sfn, this locking
-    #   and waiting mechanism avoids this problem.
-
-    # First, aquire the lock
-    with _timestamp_lock:
-        # wait more than 1 second to ensure we don't start in the same second as the previous invocation
-        time.sleep(1.1)
-        # open the subprocess
-        process = subprocess.Popen(cmd, cwd=czid_repo, stdout=sys.stderr.buffer)
-
-    # release the lock
-
-    # below is a simplified version of some of the functionality of subprocess.run
-    #   we could not use subprocess.run because it starts the process and blocks until it
-    #   it completes and we need to start the process, then release the lock, then block
-    #   until the process completes
-
-    # wait for the process to complete and get stdout and stderr
-    stdout, stderr = process.communicate()
-    # get the return code of the process
-    retcode = process.poll()
-    # if the return code is non zero then the process failed
-    if retcode:
-        # raise a CalledProcessError with the process' return code and outputs
-        raise subprocess.CalledProcessError(retcode, process.args, output=stdout, stderr=stderr)
+    subprocess.run(cmd, cwd=czid_repo, stdout=sys.stderr.buffer, check=True)
 
     workflow_major_version = workflow_version.split(".")[0]
     return (


### PR DESCRIPTION
All of this locking was to prevent naming collisions because run_sfn uses second precise timestamps for names. With a small modification to run_sfn https://github.com/chanzuckerberg/idseq/pull/449 it no longer does that so we can get rid of all of this.