### PR TITLE
Shrink AMR dockerfile

### DIFF
--- a/amr/Dockerfile
+++ b/amr/Dockerfile
@@ -25,24 +25,11 @@ RUN git clone https://github.com/rzlim08/rgi.git
 RUN mkdir -p rgi/inputs/heatmap_inputs
 RUN cd rgi/ && git checkout 646191872345e4fc70f32db1993a99c9ab331318 && python setup.py build && python setup.py test && python setup.py install
 
-RUN mkdir -p wildcard/
-
-
 # load databases
 RUN curl -LO https://czid-public-references.s3.us-west-2.amazonaws.com/test/AMRv2/card.json && \
     rgi card_annotation -i card.json && \
-    curl -LO https://czid-public-references.s3.us-west-2.amazonaws.com/test/AMRv2/wildcard_database_v3.1.0.fasta && \
-    curl -L https://czid-public-references.s3.us-west-2.amazonaws.com/test/AMRv2/61_kmer_db.json -o wildcard/61_kmer_db.json && \
-    curl -L https://czid-public-references.s3.us-west-2.amazonaws.com/test/AMRv2/all_amr_61mers.txt -o wildcard/all_amr_61mers.txt && \
-    curl -L https://czid-public-references.s3.us-west-2.amazonaws.com/test/AMRv2/index-for-model-sequences.txt -o wildcard/index-for-model-sequences.txt && \
     rgi load \
-        --wildcard_annotation wildcard_database_v3.1.0.fasta \
-        --wildcard_version 3.1.0 --wildcard_index wildcard/index-for-model-sequences.txt \
         --card_annotation card_database_v3.2.3.fasta \
-        -i card.json \
-        --kmer_database wildcard/61_kmer_db.json \
-        --amr_kmers wildcard/all_amr_61mers.txt \
-        --kmer_size 61 && \
-    rm -r wildcard/ wildcard_database_v3.1.0.fasta
+        -i card.json 
 
 COPY empty-main-header.txt /tmp/empty-main-header.txt 

--- a/amr/Dockerfile
+++ b/amr/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:20.04
 
 LABEL maintainer="CZ ID Team <idseq-tech@chanzuckerberg.com>"
 
-RUN apt-get update && apt-get -y install curl git python3 python3-pip gcc make libz-dev libncurses-dev libbz2-dev liblzma-dev g++ zip
+RUN apt-get update && apt-get -y install curl git python3 python3-pip gcc make libz-dev libncurses-dev libbz2-dev liblzma-dev g++ zip bedtools
 
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
@@ -10,7 +10,7 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN curl -L https://github.com/bbuchfink/diamond/releases/download/v0.8.36/diamond-linux64.tar.gz | tar xz && mv diamond /usr/local/bin
 RUN curl -L http://www.unafold.org/download/oligoarrayaux-3.8.tar.gz | tar xz && cd oligoarrayaux-3.8/ && ./configure && make install 
 RUN curl -L https://github.com/samtools/samtools/releases/download/1.9/samtools-1.9.tar.bz2 | tar xj && cd samtools-1.9/ && make && mv samtools /usr/local/bin/
-RUN curl -L https://github.com/arq5x/bedtools2/releases/download/v2.29.1/bedtools-2.29.1.tar.gz | tar xz && cd bedtools2 && make && mv bin/* /usr/local/bin/
+#RUN curl -L https://github.com/arq5x/bedtools2/releases/download/v2.29.1/bedtools-2.29.1.tar.gz | tar xz && cd bedtools2 && make && mv bin/* /usr/local/bin/
 RUN  curl -L https://github.com/lh3/bwa/releases/download/v0.7.17/bwa-0.7.17.tar.bz2 | tar xj && cd bwa-0.7.17/ && make &&  mv bwa /usr/local/bin/
 RUN curl -L  https://bitbucket.org/genomicepidemiology/kma/get/1.4.3.tar.gz | tar xz && cd genomicepidemiology-kma-47505a7dd4eb/ && make && mv kma kma_index kma_shm kma_update /usr/local/bin/
 

--- a/amr/Dockerfile
+++ b/amr/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:20.04
 
 LABEL maintainer="CZ ID Team <idseq-tech@chanzuckerberg.com>"
 
-RUN apt-get update && apt-get -y install curl git python3 python3-pip gcc make libz-dev libncurses-dev libbz2-dev liblzma-dev g++ zip bedtools
+RUN apt-get update && apt-get -y install curl git python3 python3-pip gcc make libz-dev libncurses-dev libbz2-dev liblzma-dev g++ zip
 
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
@@ -10,11 +10,10 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN curl -L https://github.com/bbuchfink/diamond/releases/download/v0.8.36/diamond-linux64.tar.gz | tar xz && mv diamond /usr/local/bin
 RUN curl -L http://www.unafold.org/download/oligoarrayaux-3.8.tar.gz | tar xz && cd oligoarrayaux-3.8/ && ./configure && make install 
 RUN curl -L https://github.com/samtools/samtools/releases/download/1.9/samtools-1.9.tar.bz2 | tar xj && cd samtools-1.9/ && make && mv samtools /usr/local/bin/
-#RUN curl -L https://github.com/arq5x/bedtools2/releases/download/v2.29.1/bedtools-2.29.1.tar.gz | tar xz && cd bedtools2 && make && mv bin/* /usr/local/bin/
 RUN  curl -L https://github.com/lh3/bwa/releases/download/v0.7.17/bwa-0.7.17.tar.bz2 | tar xj && cd bwa-0.7.17/ && make &&  mv bwa /usr/local/bin/
 RUN curl -L  https://bitbucket.org/genomicepidemiology/kma/get/1.4.3.tar.gz | tar xz && cd genomicepidemiology-kma-47505a7dd4eb/ && make && mv kma kma_index kma_shm kma_update /usr/local/bin/
 
-RUN apt-get update && apt-get -y install  ncbi-blast+=2.9.0-2 prodigal=1:2.6.3-4 bamtools=2.5.1+dfsg-5build1 bowtie2=2.3.5.1-6build1
+RUN apt-get update && apt-get -y install  ncbi-blast+=2.9.0-2 prodigal=1:2.6.3-4 bamtools=2.5.1+dfsg-5build1 bowtie2=2.3.5.1-6build1 bedtools=2.27.1+dfsg-4ubuntu1
 
 
 COPY requirements.txt requirements.txt

--- a/amr/run.wdl
+++ b/amr/run.wdl
@@ -14,7 +14,8 @@ workflow amr {
         File card_json = "s3://czid-public-references/test/AMRv2/card.json"
         File kmer_db = "s3://czid-public-references/test/AMRv2/61_kmer_db.json"
         File amr_kmer_db = "s3://czid-public-references/test/AMRv2/all_amr_61mers.txt"
-        File wildcard_data = "s3://czid-public-references/test/AMRv2/wildcard_data.tar.bz2"
+        File wildcard_data = "s3://czid-public-references/test/AMRv2/wildcard_database_v3.1.0.fasta"
+        File wildcard_data = "s3://czid-public-references/test/AMRv2/index-for-model-sequences.txt"
         Int min_contig_length = 100
         # Dummy values - required by SFN interface
         String s3_wd_uri = ""
@@ -367,10 +368,19 @@ task RunRgiKmerBwt {
         File kmer_db
         File amr_kmer_db
         File wildcard_data 
+        File wildcard_index
         String docker_image_id
     }
     command <<<
         set -exuo pipefail
+        
+        time rgi load \
+            --wildcard_annotation "~{wildcard_data}" \
+            --wildcard_version 3.1.0 \
+            --wildcard_index "~{wildcard_index}" \
+            --kmer_database "~{kmer_db}" \
+            --amr_kmers "~{amr_kmer_db}" \
+            --kmer_size 61
         rgi kmer_query --bwt -k 61 -i "~{output_sorted_length_100}" --output sr_species_report
     >>>
     output {

--- a/amr/run.wdl
+++ b/amr/run.wdl
@@ -71,11 +71,16 @@ workflow amr {
         kmer_db = kmer_db,
         amr_kmer_db = amr_kmer_db,
         wildcard_data = wildcard_data,
+        wildcard_index = wildcard_index,
         docker_image_id = docker_image_id
     }
     call RunRgiKmerMain { 
         input:
         main_output_json = RunRgiMain.output_json,
+        kmer_db = kmer_db,
+        amr_kmer_db = amr_kmer_db,
+        wildcard_data = wildcard_data,
+        wildcard_index = wildcard_index,
         docker_image_id = docker_image_id
     }
     call RunResultsPerSample { 
@@ -345,10 +350,21 @@ task RunResultsPerSample {
 task RunRgiKmerMain {
     input {
         File main_output_json
+        File kmer_db
+        File amr_kmer_db
+        File wildcard_data 
+        File wildcard_index
         String docker_image_id
     }
     command <<< 
         set -exuo pipefail
+        time rgi load \
+            --wildcard_annotation "~{wildcard_data}" \
+            --wildcard_version 3.1.0 \
+            --wildcard_index "~{wildcard_index}" \
+            --kmer_database "~{kmer_db}" \
+            --amr_kmers "~{amr_kmer_db}" \
+            --kmer_size 61
         rgi kmer_query --rgi -k 61 -i "~{main_output_json}" --output contig_species_report 
     >>>
     output { 

--- a/amr/run.wdl
+++ b/amr/run.wdl
@@ -15,7 +15,7 @@ workflow amr {
         File kmer_db = "s3://czid-public-references/test/AMRv2/61_kmer_db.json"
         File amr_kmer_db = "s3://czid-public-references/test/AMRv2/all_amr_61mers.txt"
         File wildcard_data = "s3://czid-public-references/test/AMRv2/wildcard_database_v3.1.0.fasta"
-        File wildcard_data = "s3://czid-public-references/test/AMRv2/index-for-model-sequences.txt"
+        File wildcard_index = "s3://czid-public-references/test/AMRv2/index-for-model-sequences.txt"
         Int min_contig_length = 100
         # Dummy values - required by SFN interface
         String s3_wd_uri = ""


### PR DESCRIPTION
* Docker build is down to 6 minutes 
* the `bedtools` make is very slow. Uses apt install for bedtools 
* dynamically loads rgi wildcard databases, should only add 1 min onto the front of the steps
