### PR TITLE
fix issue with e value calculation

### DIFF
--- a/long-read-mngs/idseq_utils/idseq_utils/paf2blast6.py
+++ b/long-read-mngs/idseq_utils/idseq_utils/paf2blast6.py
@@ -21,7 +21,9 @@ class QualityCalculations:
         return (score * self._lambda - math.log(self._k)) / math.log(2.0)
 
     def calc_evalue(self, alen, nonmatch):
-        score = alen - 2 * nonmatch
+        # we want to keep -self._lambda * score negative otherwise we could start
+        #   getting overflow errors. So we don't let score go below 0.
+        score = max(0, alen - 2 * nonmatch)
         return self._k * alen * self.genome_size * math.exp(-self._lambda * score)
 
     def calc_gap_openings(self, cigar):


### PR DESCRIPTION
We were getting overflow errors because of samples with e-values that were way too high. This PR effectively adds a maximum to e-values so this no longer happens.