### PR TITLE
increase block size for long reads pipeline

### DIFF
--- a/lib/idseq_utils/idseq_utils/diamond_scatter.py
+++ b/lib/idseq_utils/idseq_utils/diamond_scatter.py
@@ -196,7 +196,7 @@ def blastx_join(chunk_dir: str, out: str, diamond_args: str, *query: str):
             diamond_blastx(
                 cwd=tmp_dir,
                 par_tmpdir="par-tmp",
-                block_size=10,
+                block_size=100 if "long-reads" in diamond_args else 10,
                 database=db.name,
                 out=out,
                 join_chunks=chunks,


### PR DESCRIPTION
The same error as in https://github.com/chanzuckerberg/czid-workflows/pull/39 started occurring for the long-read pipeline randomly. 

I've increased the block-size by 10X but am unsure if this will account for extremely large samples. 

