### PR TITLE
Minor update of the comment

### DIFF
--- a/workflows/consensus-genome/run.wdl
+++ b/workflows/consensus-genome/run.wdl
@@ -41,7 +41,7 @@ workflow consensus_genome {
 
         # set default min_length to 350 unless midnight primers are used
         Int min_length = if primer_set == "nCoV-2019/V1200" then 250 else 350
-        # set default max_length to 1500 unless midnight primers are used
+        # set default max_length to 700 unless midnight primers are used
         Int max_length = if primer_set == "nCoV-2019/V1200" then 1500 else 700
         # normalise: default is set to 1000 to avoid spurious indels observed in validation
         Int normalise  = 1000


### PR DESCRIPTION
Per [here](https://github.com/chanzuckerberg/czid-web/blob/c3a33ebd60bd5854a9b2da6ae68a94e36e1578f4/app/services/sfn_cg_pipeline_dispatch_service.rb#L173-L174) `nCoV-2019/V1200` is midnight primer. So updated the comment section accordingly.
<img width="400" alt="image" src="https://user-images.githubusercontent.com/20667188/201198840-039499c2-8973-44ed-b12e-bfa22d952a7e.png">

