### PR TITLE
output sequence length rather than sequence

### DIFF
--- a/lib/bin/tally_counts.py
+++ b/lib/bin/tally_counts.py
@@ -82,10 +82,9 @@ def main(
     reads_to_contigs = pd.read_csv(reads_to_contigs_filepath, sep="\t", names=[
         "read_id",
         "contig_id",
-        "alignment",
+        "alignment_length",
     ])
     reads_to_contigs = reads_to_contigs[reads_to_contigs.contig_id != "*"]
-    reads_to_contigs["alignment_length"] = reads_to_contigs["alignment"].str.len()
     # we want to only keep the longest alignment for each read so reads are not double counted
     reads_to_contigs = reads_to_contigs.sort_values("alignment_length", ascending=False).drop_duplicates(["read_id"])
     reads_to_contigs = reads_to_contigs[["read_id", "contig_id"]].set_index("read_id")

--- a/lib/idseq-dag/idseq_dag/util/taxon_summary.py
+++ b/lib/idseq-dag/idseq_dag/util/taxon_summary.py
@@ -104,8 +104,8 @@ def generate_taxon_summary_from_hit_summary(
     read_to_base_count = {}
 
     with open(read_to_contig_tsv_path) as f:
-        for read_id, contig_id, sequence in csv.reader(f, delimiter="\t"):
-            read_to_base_count[read_id] = len(sequence)  # reads should be theoretically unique
+        for read_id, contig_id, sequence_length in csv.reader(f, delimiter="\t"):
+            read_to_base_count[read_id] = int(sequence_length)  # reads should be theoretically unique
             read_to_contig[read_id] = contig_id
 
     with open(hitsummary_path) as f:

--- a/workflows/long-read-mngs/run.wdl
+++ b/workflows/long-read-mngs/run.wdl
@@ -308,7 +308,7 @@ task RunReadsToContigs {
 
         # convert non-contigs.fastq file to .fasta file
         seqtk seq -a sample.non_contigs.fastq > sample.non_contigs.fasta
-        samtools view -F 0x900 sample.reads_to_contigs.sam | grep -v "^@" | awk '{ print $1 "\t" $3 "\t" length($10)}' > reads_to_contigs.tsv
+        samtools view -F 0x900 sample.reads_to_contigs.sam | awk '{ print $1 "\t" $3 "\t" length($10)}' > reads_to_contigs.tsv
     >>>
 
     output {


### PR DESCRIPTION
* The python csv module was breaking because we were outputting the sequence and it was too long
* Use `awk` to just output the sequence length
