### PR TITLE
optimize memory usage of alignment viz

### DIFF
--- a/lib/idseq-dag/idseq_dag/steps/generate_alignment_viz.py
+++ b/lib/idseq-dag/idseq_dag/steps/generate_alignment_viz.py
@@ -257,7 +257,6 @@ class PipelineStepGenerateAlignmentViz(PipelineStep):
         accession_ids = list(itertools.islice(accession_ids_generator, 0, chunk_size))
         while accession_ids:
             accession_ranges = [nt_loc_dict[a_id] for a_id in accession_ids]
-            accession_ids = list(itertools.islice(accession_ids_generator, 0, chunk_size))
             sequences = download_chunks(
                 parsed.hostname,
                 parsed.path[1:],
@@ -269,6 +268,8 @@ class PipelineStepGenerateAlignmentViz(PipelineStep):
                 ref_seq = data.replace("\n", "")
                 accession2seq[accession_id]['ref_seq'] = ref_seq
                 accession2seq[accession_id]['ref_seq_len'] = len(ref_seq)
+
+            accession_ids = list(itertools.islice(accession_ids_generator, 0, chunk_size))
 
     @staticmethod
     def compress_coverage(coverage):

--- a/lib/idseq-dag/idseq_dag/steps/generate_alignment_viz.py
+++ b/lib/idseq-dag/idseq_dag/steps/generate_alignment_viz.py
@@ -254,16 +254,16 @@ class PipelineStepGenerateAlignmentViz(PipelineStep):
         parsed = urlparse(nt_s3_path)
         chunk_size = 500
         accession_ids_generator = (a_id for a_id in accession2seq.keys() if a_id in nt_loc_dict)
-        accession_ids = list(itertools.islice(accession_ids_generator, chunk_size))
+        accession_ids = list(itertools.islice(accession_ids_generator, 0, chunk_size))
         while accession_ids:
             accession_ranges = [nt_loc_dict[a_id] for a_id in accession_ids]
+            accession_ids = list(itertools.islice(accession_ids_generator, 0, chunk_size))
             sequences = download_chunks(
                 parsed.hostname,
                 parsed.path[1:],
                 (s + hl for s, hl, _ in accession_ranges),
                 (sl for _, _, sl in accession_ranges),
             )
-            accession_ids = list(itertools.islice(accession_ids_generator, chunk_size))
 
             for accession_id, data in zip(accession_ids, sequences):
                 ref_seq = data.replace("\n", "")

--- a/lib/idseq-dag/idseq_dag/steps/generate_alignment_viz.py
+++ b/lib/idseq-dag/idseq_dag/steps/generate_alignment_viz.py
@@ -2,19 +2,20 @@ import json
 import os
 import re
 import traceback
+from tempfile import NamedTemporaryFile
 from collections import defaultdict
 from urllib.parse import urlparse
 
+from Bio import SeqIO
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio.SeqIO.FastaIO import FastaWriter
-from s3quilt import download_chunks
+from s3quilt import download_chunks_to_file
 
 from idseq_dag.engine.pipeline_step import PipelineStep
 from idseq_dag.util.lineage import INVALID_CALL_BASE_ID
 import idseq_dag.util.log as log
 import idseq_dag.util.command as command
-import idseq_dag.util.s3 as s3
 
 from idseq_dag.util.dict import open_file_db_by_extension
 
@@ -254,18 +255,20 @@ class PipelineStepGenerateAlignmentViz(PipelineStep):
         parsed = urlparse(nt_s3_path)
         accession_ids = [a_id for a_id in accession2seq.keys() if a_id in nt_loc_dict]
         accession_ranges = [nt_loc_dict[a_id] for a_id in accession_ids]
-        sequences = download_chunks(
-            parsed.hostname,
-            parsed.path[1:],
-            (s for s, _, _ in accession_ranges),
-            (hl + sl for _, hl, sl in accession_ranges),
-        )
 
-        for accession_id, data in zip(accession_ids, sequences):
-            _, ref_seq = data.split("\n", 1)
-            ref_seq = ref_seq.replace("\n", "")
-            accession2seq[accession_id]['ref_seq'] = ref_seq
-            accession2seq[accession_id]['ref_seq_len'] = len(ref_seq)
+        with NamedTemporaryFile('r', suffix=".fasta") as fasta:
+            # this step does a parallelized download to a file
+            #   though we could download straight to memory this results in too much memory usage
+            download_chunks_to_file(
+                parsed.hostname,
+                parsed.path[1:],
+                fasta.name,
+                (s for s, _, _ in accession_ranges),
+                (hl + sl for _, hl, sl in accession_ranges),
+            )
+            for accession_id, record in zip(accession_ids, SeqIO.parse(fasta.name, 'fasta')):
+                accession2seq[accession_id]['ref_seq'] = str(record.seq)
+                accession2seq[accession_id]['ref_seq_len'] = len(record.seq)
 
     @staticmethod
     def compress_coverage(coverage):

--- a/workflows/short-read-mngs/experimental.wdl
+++ b/workflows/short-read-mngs/experimental.wdl
@@ -225,6 +225,7 @@ task RunGlueJob {
     String docker_image_id
     String s3_wd_uri
   }
+
   command<<<
   # This command is specific to the CZ ID system
   set -euxo pipefail 

--- a/workflows/short-read-mngs/experimental.wdl
+++ b/workflows/short-read-mngs/experimental.wdl
@@ -230,7 +230,6 @@ task RunGlueJob {
   # This command is specific to the CZ ID system
   set -euxo pipefail 
 
-
   BUCKET=$(echo "~{s3_wd_uri}" | cut -d/ -f 3)
   PIPELINE_RUN_ID=$(echo "~{s3_wd_uri}" | cut -d/ -f 7)
   if [[ $BUCKET == "idseq-samples-sandbox" ]]; then

--- a/workflows/short-read-mngs/experimental.wdl
+++ b/workflows/short-read-mngs/experimental.wdl
@@ -264,7 +264,6 @@ task RunGlueJob {
     fi 
     i=$((i + 1))
   done
-    
   >>>
 
   runtime { 

--- a/workflows/short-read-mngs/experimental.wdl
+++ b/workflows/short-read-mngs/experimental.wdl
@@ -269,7 +269,7 @@ task RunGlueJob {
     docker: docker_image_id
   }
 }
-  
+
 
 workflow czid_experimental {
   input {

--- a/workflows/short-read-mngs/experimental.wdl
+++ b/workflows/short-read-mngs/experimental.wdl
@@ -219,6 +219,7 @@ task NonhostFastq {
     docker: docker_image_id
   }
 }
+
 task RunGlueJob {
   input {
     String docker_image_id


### PR DESCRIPTION
When switching to `s3quilt` I modified the program to load all of the sequence data into memory, then add it to `accession2seq`. At the time I thought it would be fine because I assumed that `accession2seq` would just get a pointer to the string in `sequences` but in the loop we actually create a substring which effectively double stores all of the sequences in memory. I modified the approach to only download 500 sequences at a time, then write those sequences to `accession2seq`, then download another chunk, releasing the downloaded chunk. This should keep memory usage pretty close to what it was before the switch while still benefiting from the parallel downloads.  `sequences` is also storing the accession name while `accession2seq` doesn't need that. Fortunately, we have an index for both the header (accession name) length and the sequence length so I can modify my start and length values to start at the end of the header and use just the sequence length so we no longer need to download the accession names at all. This probably isn't a huge deal because the names are way smaller than the sequences but it was an easy win.