### PR TITLE
Add long-read-mngs step descriptions

### DIFF
--- a/workflows/long-read-mngs/run.wdl
+++ b/workflows/long-read-mngs/run.wdl
@@ -67,25 +67,25 @@ task RunQualityFilter {
         python3 - << 'EOF'
         import textwrap
         with open("fastp.description.md", "w") as outfile:
-        print(textwrap.dedent("""
-        # fastp read trimming & filtering
+            print(textwrap.dedent("""
+            # fastp read trimming & filtering
 
-        Processes the reads using [fastp](https://github.com/OpenGene/fastp):
+            Processes the reads using [fastp](https://github.com/OpenGene/fastp):
 
-        1. Trim adapters
-        2. Quality score filter
-        3. Non-called base (N) filter
-        4. Length filter
-        5. Complexity filter ([custom feature](https://github.com/mlin/fastp/tree/mlin/sdust)
-            using the [SDUST algorithm](https://pubmed.ncbi.nlm.nih.gov/16796549/))
+            1. Trim adapters
+            2. Quality score filter
+            3. Non-called base (N) filter
+            4. Length filter
+            5. Complexity filter ([custom feature](https://github.com/mlin/fastp/tree/mlin/sdust)
+                using the [SDUST algorithm](https://pubmed.ncbi.nlm.nih.gov/16796549/))
 
-        fastp is run on the FASTQ file(s) from input validation:
-        ```
-        ~{fastp_invocation}
-        ```
+            fastp is run on the FASTQ file(s) from input validation:
+            ```
+            ~{fastp_invocation}
+            ```
 
-        fastp documentation can be found [here](https://github.com/OpenGene/fastp)
-        """).strip(), file=outfile)
+            fastp documentation can be found [here](https://github.com/OpenGene/fastp)
+            """).strip(), file=outfile)
         EOF
     >>>
 

--- a/workflows/long-read-mngs/run.wdl
+++ b/workflows/long-read-mngs/run.wdl
@@ -49,9 +49,19 @@ task RunQualityFilter {
         String docker_image_id
     }
 
+    String fastp_invocation = "fastp"
+            + " --html fastp.html"
+            + " --disable_adapter_trimming"
+            + " -i ${input_fastq}"
+            + " --qualified_quality_phred 9"
+            + " --length_required 100"
+            + " --low_complexity_filter --complexity_threshold 30"
+            + " --dont_eval_duplication"
+            + " -o sample_quality_filtered.fastq"
+
     command <<<
         set -euxo pipefail
-        fastp --html fastp.html --disable_adapter_trimming -i "~{input_fastq}" --qualified_quality_phred 9 --length_required 100 --low_complexity_filter --complexity_threshold 30 --dont_eval_duplication -o sample_quality_filtered.fastq
+        ~{fastp_invocation}
         filter_count sample_quality_filtered.fastq quality_filtered "No reads remaining after quality filtering"
 
         python3 - << 'EOF'

--- a/workflows/long-read-mngs/run.wdl
+++ b/workflows/long-read-mngs/run.wdl
@@ -123,6 +123,29 @@ task RunHostFilter {
         samtools view -S -b sample.hostfiltered.sam > sample.hostfiltered.bam
 
         filter_count sample.hostfiltered.fastq host_filtered "No reads remaining after host filtering"
+
+        python3 - << 'EOF'
+        import textwrap
+
+        with open("host_filter.description.md", "w") as outfile:
+            print(textwrap.dedent("""
+            Implements the step for running minimap2 host filtering.
+
+            The minimap2 aligner is used for host filtration. Unmapped reads are passed to the subsequent step. Different parameters are required for alignment of RNA vs DNA reads using minimap2. Therefore, based on the initial input validation, the appropriate parameters are selected.
+
+            If the sample is of type RNA, minimap2 uses splice-aware configuration:
+            '''
+            minimap2 -t {threads} -ax splice {minimap_host_db} {input_fastq} -o sample.hostfiltered.sam --split-prefix temp_name
+            '''
+
+            If the sample is of type DNA, minimap2 uses standard map-ont configuration:
+            '''
+            minimap2 -t {threads} -ax map-ont {minimap_host_db} {input_fastq} -o sample.hostfiltered.sam --split-prefix temp_name
+            '''
+
+            Minimap2 documentation can be found [here](https://lh3.github.io/minimap2/minimap2.html).
+            """).strip(), file=outfile)
+        EOF
     >>>
 
     output {

--- a/workflows/long-read-mngs/run.wdl
+++ b/workflows/long-read-mngs/run.wdl
@@ -68,7 +68,7 @@ task RunQualityFilter {
         import textwrap
         with open("fastp.description.md", "w") as outfile:
             print(textwrap.dedent("""
-            # fastp read trimming & filtering
+            **fastp read trimming & filtering**
 
             Processes the reads using [fastp](https://github.com/OpenGene/fastp):
 


### PR DESCRIPTION
Modifies long read mngs workflow to output a markdown file describing the step. The markdown files are later visualized by the PipelineViz

Descriptions can be found here: https://docs.google.com/spreadsheets/d/1oXui5Ory2wg9GJvEVciKu8GEoqCI62zVbMoaj3sWzzA/edit#gid=1477420657