### PR TITLE
Run tests if lib changes

### DIFF
--- a/.github/workflows/wdl-ci-integration.yml
+++ b/.github/workflows/wdl-ci-integration.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 2
       - id: list_dirs
         # only run on wdl dirs with diff
-        run: echo "{matrix}={./scripts/diff-workflows.sh |jq -cnR '[inputs|select(length>0)]')}" >> $GITHUB_OUTPUT
+        run: echo "matrix=$(./scripts/diff-workflows.sh |jq -cnR '[inputs|select(length>0)]')" >> $GITHUB_OUTPUT
 
   wdl-ci:
     runs-on: self-hosted

--- a/.github/workflows/wdl-ci-integration.yml
+++ b/.github/workflows/wdl-ci-integration.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 2
       - id: list_dirs
         # only run on wdl dirs with diff
-        run: echo "::set-output name=matrix::$(find workflows|xargs git diff --name-status HEAD^|cut -c 3-|sed 's/^workflows\///g'|xargs dirname|sed 's/\/.*$//g'|sort|uniq|jq -cnR '[inputs|select(length>0)]')"
+        run: echo "./scripts/diff-workflows.sh |jq -cnR '[inputs|select(length>0)]')" >> $GITHUB_OUTPUT
 
   wdl-ci:
     runs-on: self-hosted

--- a/.github/workflows/wdl-ci-integration.yml
+++ b/.github/workflows/wdl-ci-integration.yml
@@ -31,6 +31,7 @@ jobs:
   wdl-ci:
     runs-on: self-hosted
     needs: list-workflow-dirs
+    if: ${{ needs['list-workflow-dirs'].outputs.matrix != '[]' && needs['list-workflow-dirs'].outputs.matrix != '' }}
     strategy:
       matrix:
         workflow_dir: ${{fromJson(needs['list-workflow-dirs'].outputs.matrix)}}

--- a/.github/workflows/wdl-ci-integration.yml
+++ b/.github/workflows/wdl-ci-integration.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 2
       - id: list_dirs
         # only run on wdl dirs with diff
-        run: echo "./scripts/diff-workflows.sh |jq -cnR '[inputs|select(length>0)]')" >> $GITHUB_OUTPUT
+        run: echo "{matrix}={./scripts/diff-workflows.sh |jq -cnR '[inputs|select(length>0)]')}" >> $GITHUB_OUTPUT
 
   wdl-ci:
     runs-on: self-hosted

--- a/.github/workflows/wdl-ci.yml
+++ b/.github/workflows/wdl-ci.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           fetch-depth: 2
       - id: list_dirs
-        run: echo "./scripts/diff-workflows.sh |jq -cnR '[inputs|select(length>0)]')" >> $GITHUB_OUTPUT
+        run: echo "{matrix}={./scripts/diff-workflows.sh |jq -cnR '[inputs|select(length>0)]')}" >> $GITHUB_OUTPUT
 
   wdl-ci:
     runs-on: ubuntu-22.04

--- a/.github/workflows/wdl-ci.yml
+++ b/.github/workflows/wdl-ci.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           fetch-depth: 2
       - id: list_dirs
-        run: echo "{matrix}={./scripts/diff-workflows.sh |jq -cnR '[inputs|select(length>0)]')}" >> $GITHUB_OUTPUT
+        run: echo "matrix=$(./scripts/diff-workflows.sh |jq -cnR '[inputs|select(length>0)]')" >> $GITHUB_OUTPUT
 
   wdl-ci:
     runs-on: ubuntu-22.04

--- a/.github/workflows/wdl-ci.yml
+++ b/.github/workflows/wdl-ci.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           fetch-depth: 2
       - id: list_dirs
-        run: echo "::set-output name=matrix::$(find workflows|xargs git diff --name-status HEAD^|cut -c 3-|sed 's/^workflows\///g'|xargs dirname|sed 's/\/.*$//g'|sort|uniq|jq -cnR '[inputs|select(length>0)]')"
+        run: echo "./scripts/diff-workflows.sh |jq -cnR '[inputs|select(length>0)]')" >> $GITHUB_OUTPUT
 
   wdl-ci:
     runs-on: ubuntu-22.04

--- a/scripts/diff-workflows.sh
+++ b/scripts/diff-workflows.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -euo pipefail
+
+WORKFLOWS=$(git diff --name-status HEAD^ workflows/ | cut -d/ -f2)
+
+if [ -n "$(git diff --name-status HEAD^ lib)" ]; then 
+    # if the lib/ folder changes, run tests for anything that depends on it
+    WORKFLOWS+='\n'"short-read-mngs"
+    WORKFLOWS+='\n'"long-read-mngs"
+fi
+
+echo -e "$WORKFLOWS" | sort | uniq 


### PR DESCRIPTION

* `set-output` will be deprecated next month so I converted to $GITHUB_OUTPUT
* Simplified the bash oneliner from `find workflows|xargs git diff --name-status HEAD^|cut -c 3-|sed 's/^workflows\///g'|xargs dirname|sed 's/\/.*$//g'` to `git diff --name-status HEAD^ workflows/ | cut -d/ -f2` . Not sure if this covers all edge cases
* if `lib/` changes, automatically runs tests for both short-read-mngs and long-read-mngs (can add more workflows if they start using `lib/`