### PR TITLE
Remove unmapped reads from annotated output file

### DIFF
--- a/lib/idseq-dag/idseq_dag/steps/generate_annotated_fasta.py
+++ b/lib/idseq-dag/idseq_dag/steps/generate_annotated_fasta.py
@@ -67,6 +67,7 @@ def _annotate_fasta_with_accessions(
     if unique_output_file:
         unique_output_file.close()
 
+
 def output_clusters(output_unmapped_fasta_f, unique_output_file, read_header, read_sequence, clusters_dict):
     unique_output_file.write(read_header + "\n")
     unique_output_file.write(read_sequence)
@@ -83,48 +84,6 @@ def output_clusters(output_unmapped_fasta_f, unique_output_file, read_header, re
         other_header = UNMAPPED_HEADER_PREFIX + other_key + header_suffix
         output_unmapped_fasta_f.write(other_header + "\n")
         output_unmapped_fasta_f.write(read_sequence)  # write duplicate seq
-
-
-def _generate_unidentified_fasta(
-    input_fa,
-    output_fa,
-    clusters_dict=None,
-    unique_output_fa=None
-):
-    """
-    Generates files with all unmapped reads. If COUNT_ALL, which was added
-    in v4, then include non-unique reads extracted upstream by czid-dedup.
-
-    unique_output_fa exists primarily for counting. See count_reads above.
-    """
-    unique_output_file = open(unique_output_fa, "w") if clusters_dict else None
-    with open(output_fa, "w") as output_file:
-        for read in fasta.iterator(input_fa):
-            if not read.header.startswith(UNMAPPED_HEADER_PREFIX):
-                continue
-
-            output_file.write(read.header + "\n")
-            output_file.write(read.sequence + "\n")
-            if unique_output_file:
-                unique_output_file.write(read.header + "\n")
-                unique_output_file.write(read.sequence + "\n")
-
-            if clusters_dict:
-                # get inner part of header like
-                # '>NR::NT::NB501961:14:HM7TLBGX2:4:23511:18703:20079/2'
-                line = read.header
-                header_suffix = ""
-                if line[-2:-1] == "/":  # /1 or /2
-                    line, header_suffix = line[:-2], line[-2:]
-                    assert header_suffix in ('/1', '/2')
-                    assert len(read.header) == len(line) + len(header_suffix)
-
-                key = line.split(UNMAPPED_HEADER_PREFIX)[1]
-                other_keys = clusters_dict[key][1:]  # key should always be present
-                for other_key in other_keys:
-                    other_header = UNMAPPED_HEADER_PREFIX + other_key + header_suffix
-                    output_file.write(other_header + "\n")
-                    output_file.write(read.sequence + "\n")  # write duplicate seq
 
 
 def generate_annotated_fasta(

--- a/lib/idseq-dag/idseq_dag/steps/generate_annotated_fasta.py
+++ b/lib/idseq-dag/idseq_dag/steps/generate_annotated_fasta.py
@@ -17,7 +17,15 @@ def _old_read_name(new_read_name):
     return new_read_name.split(":", 4)[-1]
 
 
-def _annotate_fasta_with_accessions(merged_input_fasta, nt_m8, nr_m8, output_fasta):
+def _annotate_fasta_with_accessions(
+    merged_input_fasta, 
+    nt_m8, 
+    nr_m8, 
+    output_fasta, 
+    output_unmapped_fasta, 
+    clusters_dict = None, 
+    unique_output_fa = None
+    ):
     def get_map(blastn_6_path):
         with open(blastn_6_path) as blastn_6_f:
             return {row["qseqid"]: row["sseqid"] for row in BlastnOutput6NTRerankedReader(blastn_6_f, filter_invalid=True)}
@@ -25,24 +33,58 @@ def _annotate_fasta_with_accessions(merged_input_fasta, nt_m8, nr_m8, output_fas
     nt_map = get_map(nt_m8)
     nr_map = get_map(nr_m8)
 
+    unique_output_file = open(unique_output_fa, "w") if clusters_dict else None
+
     with open(merged_input_fasta, 'r', encoding='utf-8') as input_fasta_f:
         with open(output_fasta, 'w') as output_fasta_f:
-            sequence_name = input_fasta_f.readline()
-            sequence_data = input_fasta_f.readline()
-
-            # TODO: (tmorse) fasta parsing
-            while sequence_name and sequence_data:
-                read_id = sequence_name.rstrip().lstrip('>')
-                # Need to annotate NR then NT in this order for alignment viz
-                # Its inverse is old_read_name()
-                new_read_name = "NR:{nr_accession}:NT:{nt_accession}:{read_id}".format(
-                    nr_accession=nr_map.get(read_id, ''),
-                    nt_accession=nt_map.get(read_id, ''),
-                    read_id=read_id)
-                output_fasta_f.write(">%s\n" % new_read_name)
-                output_fasta_f.write(sequence_data)
+            with open(output_unmapped_fasta, "w") as output_unmapped_fasta_f:
                 sequence_name = input_fasta_f.readline()
                 sequence_data = input_fasta_f.readline()
+
+                # TODO: (tmorse) fasta parsing
+                while sequence_name and sequence_data:
+                    read_id = sequence_name.rstrip().lstrip('>')
+                    # Need to annotate NR then NT in this order for alignment viz
+                    # Its inverse is old_read_name()
+                    nr_accession = nr_map.get(read_id, '')
+                    nt_accession = nt_map.get(read_id, '')
+                    new_read_name = ">NR:{nr_accession}:NT:{nt_accession}:{read_id}".format(
+                        nr_accession=nr_accession,
+                        nt_accession=nt_accession,
+                        read_id=read_id)
+                    if nt_accession or nr_accession:
+                        output_fasta_f.write("%s\n" % new_read_name)
+                        output_fasta_f.write(sequence_data)
+                    else:
+                        output_unmapped_fasta_f.write("%s\n" % new_read_name)
+                        output_unmapped_fasta_f.write(sequence_data)
+                        if clusters_dict and unique_output_file:
+                            output_clusters(
+                                output_unmapped_fasta_f,
+                                unique_output_file, 
+                                new_read_name, 
+                                sequence_data, 
+                                clusters_dict, 
+                            )
+                    sequence_name = input_fasta_f.readline()
+                    sequence_data = input_fasta_f.readline()
+
+def output_clusters(output_unmapped_fasta_f, unique_output_file, read_header, read_sequence, clusters_dict):
+    unique_output_file.write(read_header + "\n")
+    unique_output_file.write(read_sequence)
+    line = read_header
+    header_suffix = ""
+    if line[-2:-1] == "/":  # /1 or /2
+        line, header_suffix = line[:-2], line[-2:]
+        assert header_suffix in ('/1', '/2')
+        assert len(read_header) == len(line) + len(header_suffix)
+
+    key = line.split(UNMAPPED_HEADER_PREFIX)[1]
+    other_keys = clusters_dict[key][1:]  # key should always be present
+    for other_key in other_keys:
+        other_header = UNMAPPED_HEADER_PREFIX + other_key + header_suffix
+        output_unmapped_fasta_f.write(other_header + "\n")
+        output_unmapped_fasta_f.write(read_sequence)  # write duplicate seq
 
 
 def _generate_unidentified_fasta(
@@ -105,12 +147,14 @@ def generate_annotated_fasta(
     else:
         clusters_dict = None
 
-    _annotate_fasta_with_accessions(pre_alignment_fa_path, nt_m8_path, nr_m8_path, annotated_fasta_path)
-    _generate_unidentified_fasta(
-        annotated_fasta_path,
+    _annotate_fasta_with_accessions(
+        pre_alignment_fa_path, 
+        nt_m8_path, 
+        nr_m8_path, 
+        annotated_fasta_path, 
         unidentified_fasta_path,
-        clusters_dict,
-        unique_unidentified_fasta
+        clusters_dict = clusters_dict,
+        unique_output_fa = unique_unidentified_fasta,
     )
 
 

--- a/lib/idseq-dag/idseq_dag/steps/generate_annotated_fasta.py
+++ b/lib/idseq-dag/idseq_dag/steps/generate_annotated_fasta.py
@@ -18,14 +18,14 @@ def _old_read_name(new_read_name):
 
 
 def _annotate_fasta_with_accessions(
-    merged_input_fasta, 
-    nt_m8, 
-    nr_m8, 
-    output_fasta, 
-    output_unmapped_fasta, 
-    clusters_dict = None, 
-    unique_output_fa = None
-    ):
+    merged_input_fasta,
+    nt_m8,
+    nr_m8,
+    output_fasta,
+    output_unmapped_fasta,
+    clusters_dict=None,
+    unique_output_fa=None
+):
     def get_map(blastn_6_path):
         with open(blastn_6_path) as blastn_6_f:
             return {row["qseqid"]: row["sseqid"] for row in BlastnOutput6NTRerankedReader(blastn_6_f, filter_invalid=True)}
@@ -35,39 +35,37 @@ def _annotate_fasta_with_accessions(
 
     unique_output_file = open(unique_output_fa, "w") if clusters_dict else None
 
-    with open(merged_input_fasta, 'r', encoding='utf-8') as input_fasta_f:
-        with open(output_fasta, 'w') as output_fasta_f:
-            with open(output_unmapped_fasta, "w") as output_unmapped_fasta_f:
-                sequence_name = input_fasta_f.readline()
-                sequence_data = input_fasta_f.readline()
+    with open(merged_input_fasta, 'r', encoding='utf-8') as input_fasta_f, open(output_fasta, 'w') as output_fasta_f, open(output_unmapped_fasta, "w") as output_unmapped_fasta_f:
+        sequence_name = input_fasta_f.readline()
+        sequence_data = input_fasta_f.readline()
 
-                # TODO: (tmorse) fasta parsing
-                while sequence_name and sequence_data:
-                    read_id = sequence_name.rstrip().lstrip('>')
-                    # Need to annotate NR then NT in this order for alignment viz
-                    # Its inverse is old_read_name()
-                    nr_accession = nr_map.get(read_id, '')
-                    nt_accession = nt_map.get(read_id, '')
-                    new_read_name = ">NR:{nr_accession}:NT:{nt_accession}:{read_id}".format(
-                        nr_accession=nr_accession,
-                        nt_accession=nt_accession,
-                        read_id=read_id)
-                    if nt_accession or nr_accession:
-                        output_fasta_f.write("%s\n" % new_read_name)
-                        output_fasta_f.write(sequence_data)
-                    else:
-                        output_unmapped_fasta_f.write("%s\n" % new_read_name)
-                        output_unmapped_fasta_f.write(sequence_data)
-                        if clusters_dict and unique_output_file:
-                            output_clusters(
-                                output_unmapped_fasta_f,
-                                unique_output_file, 
-                                new_read_name, 
-                                sequence_data, 
-                                clusters_dict, 
-                            )
-                    sequence_name = input_fasta_f.readline()
-                    sequence_data = input_fasta_f.readline()
+        # TODO: (tmorse) fasta parsing
+        while sequence_name and sequence_data:
+            read_id = sequence_name.rstrip().lstrip('>')
+            # Need to annotate NR then NT in this order for alignment viz
+            # Its inverse is old_read_name()
+            nr_accession = nr_map.get(read_id, '')
+            nt_accession = nt_map.get(read_id, '')
+            new_read_name = ">NR:{nr_accession}:NT:{nt_accession}:{read_id}".format(
+                nr_accession=nr_accession,
+                nt_accession=nt_accession,
+                read_id=read_id)
+            output_file = output_fasta_f if nt_accession or nr_accession else output_unmapped_fasta_f
+            output_file.write(new_read_name + '\n')
+            output_file.write(sequence_data)
+
+            if not (nt_accession or nr_accession) and clusters_dict and unique_output_file:
+                output_clusters(
+                    output_unmapped_fasta_f,
+                    unique_output_file,
+                    new_read_name,
+                    sequence_data,
+                    clusters_dict,
+                )
+            sequence_name = input_fasta_f.readline()
+            sequence_data = input_fasta_f.readline()
+    if unique_output_file:
+        unique_output_file.close()
 
 def output_clusters(output_unmapped_fasta_f, unique_output_file, read_header, read_sequence, clusters_dict):
     unique_output_file.write(read_header + "\n")
@@ -148,13 +146,13 @@ def generate_annotated_fasta(
         clusters_dict = None
 
     _annotate_fasta_with_accessions(
-        pre_alignment_fa_path, 
-        nt_m8_path, 
-        nr_m8_path, 
-        annotated_fasta_path, 
+        pre_alignment_fa_path,
+        nt_m8_path,
+        nr_m8_path,
+        annotated_fasta_path,
         unidentified_fasta_path,
-        clusters_dict = clusters_dict,
-        unique_output_fa = unique_unidentified_fasta,
+        clusters_dict=clusters_dict,
+        unique_output_fa=unique_unidentified_fasta,
     )
 
 


### PR DESCRIPTION
* Rather than creating the annotated output file then the unmapped file, creates both at the same time
* If read has hits, then outputs in annotated output file. Otherwise outputs in unmapped file. 
