### PR TITLE
[modernized host filter] add ERCC and gene-level outputs to kallisto

### DIFF
--- a/workflows/short-read-mngs/Dockerfile
+++ b/workflows/short-read-mngs/Dockerfile
@@ -197,7 +197,7 @@ WORKDIR /hisat2
 RUN wget -nv -O /tmp/HISAT2.zip https://cloud.biohpc.swmed.edu/index.php/s/oTtGWbWjaxsQ2Ho/download \
         && unzip /tmp/HISAT2.zip && mv hisat2-*/* . && rm /tmp/HISAT2.zip
 RUN curl -L https://github.com/pachterlab/kallisto/releases/download/v0.46.1/kallisto_linux-v0.46.1.tar.gz | tar xz -C /
-RUN pip3 install 'gtfparse>=2,<3'
+RUN pip3 install 'gtfparse>=1.3.0,<2'
 
 # Uninstall build only dependencies
 RUN apt-get purge -y g++ libperl4-corelibs-perl make

--- a/workflows/short-read-mngs/Dockerfile
+++ b/workflows/short-read-mngs/Dockerfile
@@ -197,7 +197,7 @@ WORKDIR /hisat2
 RUN wget -nv -O /tmp/HISAT2.zip https://cloud.biohpc.swmed.edu/index.php/s/oTtGWbWjaxsQ2Ho/download \
         && unzip /tmp/HISAT2.zip && mv hisat2-*/* . && rm /tmp/HISAT2.zip
 RUN curl -L https://github.com/pachterlab/kallisto/releases/download/v0.46.1/kallisto_linux-v0.46.1.tar.gz | tar xz -C /
-RUN pip3 install gtfparse~=2
+RUN pip3 install 'gtfparse>=2,<3'
 
 # Uninstall build only dependencies
 RUN apt-get purge -y g++ libperl4-corelibs-perl make

--- a/workflows/short-read-mngs/Dockerfile
+++ b/workflows/short-read-mngs/Dockerfile
@@ -116,7 +116,7 @@ RUN chmod +x /usr/bin/PriceSeqFilter
 RUN curl -Ls https://github.com/chanzuckerberg/s3parcp/releases/download/v0.2.0-alpha/s3parcp_0.2.0-alpha_Linux_x86_64.tar.gz | tar -C /usr/bin -xz s3parcp
 
 # FIXME: check if use of pandas, pysam is necessary
-RUN pip3 install pysam==0.14.1 pandas==1.3.5
+RUN pip3 install pysam==0.14.1 pandas==1.1.5
 
 # Workaround for srst2 refusing to work with upstream bowtie2 and samtools
 # FIXME: replace srst2 with a more appropriate tool
@@ -197,7 +197,7 @@ WORKDIR /hisat2
 RUN wget -nv -O /tmp/HISAT2.zip https://cloud.biohpc.swmed.edu/index.php/s/oTtGWbWjaxsQ2Ho/download \
         && unzip /tmp/HISAT2.zip && mv hisat2-*/* . && rm /tmp/HISAT2.zip
 RUN curl -L https://github.com/pachterlab/kallisto/releases/download/v0.46.1/kallisto_linux-v0.46.1.tar.gz | tar xz -C /
-RUN pip3 install gtfparse==1.3.0
+RUN pip3 install gtfparse==1.2.1
 
 # Uninstall build only dependencies
 RUN apt-get purge -y g++ libperl4-corelibs-perl make

--- a/workflows/short-read-mngs/Dockerfile
+++ b/workflows/short-read-mngs/Dockerfile
@@ -184,6 +184,7 @@ RUN curl -Ls https://github.com/chanzuckerberg/s3parcp/releases/download/v0.2.0-
 # fastp (libdeflate libisal (dh-autoreconf nasm))
 # hisat2
 # bowtie2 [already installed]
+# kallisto + python gtfparse
 WORKDIR /tmp
 RUN wget -nv -O - https://github.com/intel/isa-l/archive/refs/tags/v2.30.0.tar.gz | tar zx
 RUN cd isa-l-* && ./autogen.sh && ./configure && make -j8 && make install
@@ -196,6 +197,7 @@ WORKDIR /hisat2
 RUN wget -nv -O /tmp/HISAT2.zip https://cloud.biohpc.swmed.edu/index.php/s/oTtGWbWjaxsQ2Ho/download \
         && unzip /tmp/HISAT2.zip && mv hisat2-*/* . && rm /tmp/HISAT2.zip
 RUN curl -L https://github.com/pachterlab/kallisto/releases/download/v0.46.1/kallisto_linux-v0.46.1.tar.gz | tar xz -C /
+RUN pip3 install gtfparse~=2
 
 # Uninstall build only dependencies
 RUN apt-get purge -y g++ libperl4-corelibs-perl make

--- a/workflows/short-read-mngs/Dockerfile
+++ b/workflows/short-read-mngs/Dockerfile
@@ -116,7 +116,7 @@ RUN chmod +x /usr/bin/PriceSeqFilter
 RUN curl -Ls https://github.com/chanzuckerberg/s3parcp/releases/download/v0.2.0-alpha/s3parcp_0.2.0-alpha_Linux_x86_64.tar.gz | tar -C /usr/bin -xz s3parcp
 
 # FIXME: check if use of pandas, pysam is necessary
-RUN apt-get -q install -y python3-pysam python3-pandas
+RUN pip3 install pysam==0.14.1 pandas==0.25.3
 
 # Workaround for srst2 refusing to work with upstream bowtie2 and samtools
 # FIXME: replace srst2 with a more appropriate tool
@@ -197,7 +197,7 @@ WORKDIR /hisat2
 RUN wget -nv -O /tmp/HISAT2.zip https://cloud.biohpc.swmed.edu/index.php/s/oTtGWbWjaxsQ2Ho/download \
         && unzip /tmp/HISAT2.zip && mv hisat2-*/* . && rm /tmp/HISAT2.zip
 RUN curl -L https://github.com/pachterlab/kallisto/releases/download/v0.46.1/kallisto_linux-v0.46.1.tar.gz | tar xz -C /
-RUN pip3 install 'gtfparse>=1.3.0,<2'
+RUN pip3 install gtfparse==1.3.0
 
 # Uninstall build only dependencies
 RUN apt-get purge -y g++ libperl4-corelibs-perl make

--- a/workflows/short-read-mngs/Dockerfile
+++ b/workflows/short-read-mngs/Dockerfile
@@ -116,7 +116,7 @@ RUN chmod +x /usr/bin/PriceSeqFilter
 RUN curl -Ls https://github.com/chanzuckerberg/s3parcp/releases/download/v0.2.0-alpha/s3parcp_0.2.0-alpha_Linux_x86_64.tar.gz | tar -C /usr/bin -xz s3parcp
 
 # FIXME: check if use of pandas, pysam is necessary
-RUN pip3 install pysam==0.14.1 pandas==0.25.3
+RUN pip3 install pysam==0.14.1 pandas==1.3.5
 
 # Workaround for srst2 refusing to work with upstream bowtie2 and samtools
 # FIXME: replace srst2 with a more appropriate tool


### PR DESCRIPTION
The kallisto step gains two new derivative output files:
* `ERCC_counts.tsv`: Estimated read counts for the ERCC sequences only (two-column TSV: ERCC_id, est_counts)
* `gene_abundance.tsv`: gene-level est_counts and tpm, computed by summing over all transcripts for each gene
* (and `abundance.tsv` is renamed to `transcript_abundance.tsv`)

To get the `gene_abundance.tsv` we need a new input `gtf_gz`, the Ensembl GTF file for the host species that will tell it how to map the transcript IDs in `transcript_abundance.tsv` onto gene IDs for the roll-up. The input is optional and if absent then the `gene_abundance.tsv` output is omitted too.

Note: docker image update needed to install & upgrade some dependencies.