### PR TITLE
[SC-228638] Cleanup unused code

### DIFF
--- a/workflows/amr/run.wdl
+++ b/workflows/amr/run.wdl
@@ -7,7 +7,6 @@ workflow amr {
         Array[File]? non_host_reads
         File? raw_reads_0
         File? raw_reads_1
-        Int? total_reads
         File? contigs
         String docker_image_id
         String sample_name
@@ -39,11 +38,6 @@ workflow amr {
             ),
             min_contig_length = min_contig_length,
             docker_image_id = host_filtering_docker_image_id,
-        }
-        call GetTotalReads { 
-            input:
-            total_read_file = select_first([host_filter_stage.input_read_count]),
-            docker_image_id = host_filtering_docker_image_id
         }
     }
     call RunRgiBwtKma {
@@ -97,7 +91,6 @@ workflow amr {
         kma_output = RunRgiBwtKma.kma_amr_results,
         kma_species_output = RunRgiKmerBwt.kma_species_calling,
         gene_coverage = MakeGeneCoverage.output_gene_coverage,
-        total_reads = select_first([total_reads, GetTotalReads.total_reads]),
         docker_image_id = docker_image_id,
         sample_name = sample_name
     }
@@ -149,25 +142,6 @@ workflow amr {
 
 }
 
-task GetTotalReads { 
-    input {
-        File total_read_file
-        String docker_image_id
-    }
-
-    command <<<
-        jq '.fastqs' > total_reads.txt < "~{total_read_file}"
-    >>>
-
-    output {
-        Int total_reads = read_int("total_reads.txt")
-    }
-
-    runtime {
-        docker: docker_image_id
-    }
-}
-
 task RunResultsPerSample {
     input {
         File main_output
@@ -175,7 +149,6 @@ task RunResultsPerSample {
         File kma_output
         File kma_species_output
         File gene_coverage
-        Int total_reads
         String docker_image_id
         String sample_name
     }


### PR DESCRIPTION
For exposing `total_reads`, `rpm`, and `dpm` in the AMR output file `combined_amr_results.csv`, I ended up going with a solution on the web app side, so I'm removing the code that was added to originally support this on the pipeline side.