### PR TITLE
[Bugfix] Handle Empty Annotated Fasta file

### DIFF
--- a/lib/idseq-dag/idseq_dag/steps/generate_taxid_locator.py
+++ b/lib/idseq-dag/idseq_dag/steps/generate_taxid_locator.py
@@ -111,8 +111,8 @@ class PipelineStepGenerateTaxidLocator(PipelineStep):
             return seq_name.replace('>', ':').split(":").index(taxid_field) + 1
         else:
             # if seq_name is empty the input_fasta is empty
-            return -1 
-            
+            return -1
+
     @staticmethod
     def get_taxid(seq_name, taxid_field):
         parts = seq_name.decode('utf-8')

--- a/lib/idseq-dag/idseq_dag/steps/generate_taxid_locator.py
+++ b/lib/idseq-dag/idseq_dag/steps/generate_taxid_locator.py
@@ -107,8 +107,12 @@ class PipelineStepGenerateTaxidLocator(PipelineStep):
     def get_taxid_field_num(taxid_field, input_fasta):
         with open(input_fasta) as f:
             seq_name = f.readline()
-        return seq_name.replace('>', ':').split(":").index(taxid_field) + 1
-
+        if seq_name:
+            return seq_name.replace('>', ':').split(":").index(taxid_field) + 1
+        else:
+            # if seq_name is empty the input_fasta is empty
+            return -1 
+            
     @staticmethod
     def get_taxid(seq_name, taxid_field):
         parts = seq_name.decode('utf-8')


### PR DESCRIPTION
* The change [here](https://github.com/chanzuckerberg/czid-workflows/pull/174) made it so that it was possible that the annotated taxid file was empty in the case where all reads were unmapped
* This condition had not been handled yet. It assumed that there was at least 1 read in the fasta file
* If there are no reads, returns an arbitrary -1 value