### PR TITLE
Fix long reads errors

### DIFF
--- a/lib/bin/filter_count
+++ b/lib/bin/filter_count
@@ -24,10 +24,10 @@ else
 fi
 LINES=$(echo $WC_OUT | cut -f 2 -d ' ')
 CHARS=$(echo $WC_OUT | cut -f 3 -d ' ')
-BASES=$(expr $CHARS - $LINES)
+BASES=$(($CHARS - $LINES))
 echo "{ \"$2_reads\": \"$LINES\" }" > $2_reads.count
 echo "{ \"$2_bases\": \"$BASES\" }" > $2_bases.count
 
 if [[ $LINES == 0 && -n $3 ]]; then
-    raise_error InsufficientReadsError $3
+    raise_error InsufficientReadsError "$3"
 fi

--- a/workflows/long-read-mngs/run.wdl
+++ b/workflows/long-read-mngs/run.wdl
@@ -22,9 +22,13 @@ task RunValidateInput {
 
         python3 <<CODE
         from Bio import SeqIO
-
-        for record in SeqIO.parse("sample_validated.fastq", "fastq"):
-            pass
+        import json
+        
+        try: 
+            for record in SeqIO.parse("sample_validated.fastq", "fastq"):
+                pass
+        except ValueError as e:
+            exit(json.dumps(dict(wdl_error_message=True, error="InvalidInputFileError", cause=str(e))))
         CODE
 
         filter_count sample_validated.fastq validated "No reads remaining after input validation"


### PR DESCRIPTION
* removes `expr` and uses bash arithmetic
* catches error in SeqIO reading fastq file
* quotes argument to `raise_error`