### PR TITLE
add primer_bed and ref fasta file to zipped outputs

### DIFF
--- a/workflows/consensus-genome/run.wdl
+++ b/workflows/consensus-genome/run.wdl
@@ -260,6 +260,8 @@ workflow consensus_genome {
                     RunMinion.vcf,
                     RealignConsensus.muscle_output,
                     RunMinion.muscle_output,
+                    primer_bed,
+                    ref_fasta if ref_fasta is not None else "",  # only return the refernce file if one was provided (general viral WGS case)
                 ])
             ])),
             docker_image_id = docker_image_id

--- a/workflows/consensus-genome/run.wdl
+++ b/workflows/consensus-genome/run.wdl
@@ -261,7 +261,7 @@ workflow consensus_genome {
                     RealignConsensus.muscle_output,
                     RunMinion.muscle_output,
                     primer_bed,
-                    ref_fasta if ref_fasta is not None else "",  # only return the refernce file if one was provided (general viral WGS case)
+                    select_first([ref_fasta, ""]),   # only return the refernce file if one was provided (general viral WGS case)
                 ])
             ])),
             docker_image_id = docker_image_id


### PR DESCRIPTION
[SC ticket](https://app.shortcut.com/idseq/story/230372/pipeline-add-reference-fasta-and-primer-bed-file-to-cg-workflow-outputs)

 users will want to download their primer bed and reference file from the UI that they provided during upload (in consensus genome report)