### PR TITLE
[BUG] fix unset bash variable

### DIFF
--- a/lib/bin/filter_count
+++ b/lib/bin/filter_count
@@ -10,7 +10,7 @@
 #   3 (optional): a message to display to the user if all reads are filtered out at this step
 #     if this is omitted an error is not raised for insufficient reads
 
-set -euo pipefail
+set -eo pipefail
 
 if [[ $1 == *gz ]]; then
     # gzip -t checks the whole file so might be a bit slow. 


### PR DESCRIPTION
* I should have fixed this in an earlier fix, but we can't raise an error if there's an unset bash variable in filter count since we allow an optional variable $3