### PR TITLE
Fix tsvToSam for no contigs

### DIFF
--- a/workflows/amr/run.wdl
+++ b/workflows/amr/run.wdl
@@ -627,8 +627,10 @@ task tsvToSam {
         # Load columns of interest from CSV and drop rows with at least one NaN
         df = pd.read_csv("~{final_summary}", sep="\t", usecols=[COLUMN_GENE_ID, COLUMN_CONTIG_NAME])
 
-        # Create BAM with mock reference lengths for the header (do this before df.dropna() so we list all gene IDs in the SAM header)
-        gene_ids = df[COLUMN_GENE_ID].dropna().unique().tolist()
+        # Create BAM with mock reference lengths for the header (do this before df.dropna() so we
+        # list all gene IDs in the SAM header). If no gene IDs are found at all, have a mock gene
+        # to make sure we can create the SAM file with no errors (web app will look for that file)
+        gene_ids = df[COLUMN_GENE_ID].dropna().unique().tolist() or ["NoGenes"]
         output_bam = pysam.AlignmentFile(OUTPUT_BAM, "wb", reference_names=gene_ids, reference_lengths=[100] * len(gene_ids))
 
         # Remove extraneous _* at the end of contig names

--- a/workflows/amr/run.wdl
+++ b/workflows/amr/run.wdl
@@ -95,6 +95,13 @@ workflow amr {
         sample_name = sample_name
     }
 
+    call tsvToSam { 
+        input: 
+        contigs = select_first([contigs, RunSpades.contigs]),
+        final_summary = RunResultsPerSample.final_summary,
+        docker_image_id = docker_image_id
+    }
+
     call ZipOutputs {
         input:
         contigs_in = select_first([contigs, RunSpades.contigs]),

--- a/workflows/amr/run.wdl
+++ b/workflows/amr/run.wdl
@@ -625,14 +625,15 @@ task tsvToSam {
         contigs_fasta = pysam.Fastafile("~{contigs}")
 
         # Load columns of interest from CSV and drop rows with at least one NaN
-        df = pd.read_csv("~{final_summary}", sep="\t", usecols=[COLUMN_GENE_ID, COLUMN_CONTIG_NAME]).dropna()
+        df = pd.read_csv("~{final_summary}", sep="\t", usecols=[COLUMN_GENE_ID, COLUMN_CONTIG_NAME])
+
+        # Create BAM with mock reference lengths for the header (do this before df.dropna() so we list all gene IDs in the SAM header)
+        gene_ids = df[COLUMN_GENE_ID].dropna().unique().tolist()
+        output_bam = pysam.AlignmentFile(OUTPUT_BAM, "wb", reference_names=gene_ids, reference_lengths=[100] * len(gene_ids))
 
         # Remove extraneous _* at the end of contig names
+        df = df.dropna()
         df[COLUMN_CONTIG_NAME] = df[COLUMN_CONTIG_NAME].apply(lambda x: x[:x.rindex("_")])
-
-        # Create BAM file using mock reference lengths for the header
-        gene_ids = df[COLUMN_GENE_ID].unique().tolist()
-        output_bam = pysam.AlignmentFile(OUTPUT_BAM, "wb", reference_names=gene_ids, reference_lengths=[100] * len(gene_ids))
 
         # Go through each line of the TSV and create a SAM record (https://wckdouglas.github.io/2021/12/pytest-with-pysam)
         for index, row in df.iterrows():


### PR DESCRIPTION
This PR is to fix the AMR pipeline errors when no contigs map to genes, which caused us to try creating a SAM file header without any sequences, which is not supported:

```
ValueError: either supply options `template`, `header`, `text` or  both `reference_names` and `reference_lengths` for writing
```
