### PR TITLE
Add Bowtie2 ERCCs to host filter WDL outputs

### DIFF
--- a/workflows/short-read-mngs/host_filter.wdl
+++ b/workflows/short-read-mngs/host_filter.wdl
@@ -165,6 +165,7 @@ workflow czid_host_filter {
     File? bowtie2_host_filtered2_fastq = bowtie2_filter.bowtie2_host_filtered2_fastq
     File bowtie2_host_filtered_out_count = bowtie2_filter.reads_out_count
     File bowtie2_host_filtered_bam = bowtie2_filter.bam
+    File bowtie2_ERCC_counts_tsv = bowtie2_filter.bowtie2_ERCC_counts
     File hisat2_host_filtered1_fastq = hisat2_filter.hisat2_host_filtered1_fastq
     File? hisat2_host_filtered2_fastq = hisat2_filter.hisat2_host_filtered2_fastq
     File hisat2_host_filtered_out_count = hisat2_filter.reads_out_count


### PR DESCRIPTION
I recently ran a sample on 8.1.1 but didn't see the bowtie2_ERCC_counts.tsv as a pipeline output, this PR adds it