### PR TITLE
Update ERCC count output name

### DIFF
--- a/workflows/short-read-mngs/host_filter.wdl
+++ b/workflows/short-read-mngs/host_filter.wdl
@@ -165,7 +165,7 @@ workflow czid_host_filter {
     File bowtie2_ercc_filtered1_fastq = ercc_bowtie2_filter.bowtie2_ercc_filtered1_fastq
     File? bowtie2_ercc_filtered2_fastq = ercc_bowtie2_filter.bowtie2_ercc_filtered2_fastq
     File bowtie2_ERCC_counts_tsv = ercc_bowtie2_filter.bowtie2_ercc_counts
-    File ercc_bowtie2_filter_count = ercc_bowtie2_filter.reads_out_count
+    File bowtie2_ercc_filtered_out_count = ercc_bowtie2_filter.reads_out_count
 
     File fastp_out_fastp1_fastq = fastp_qc.fastp1_fastq
     File? fastp_out_fastp2_fastq = fastp_qc.fastp2_fastq


### PR DESCRIPTION
Renames the ERCC count output name. 
 `ercc_bowtie2_filter_count` -> `bowtie2_ercc_filtered_out_count`

This old count output name `ercc_bowtie2_filter_count` strays from the pattern we've been using to name the SFN output counts `bowtie2_ercc_filtered_out_count`