### PR TITLE
[CZID-7837] Exit early if the assembly failed

### DIFF
--- a/workflows/amr/run.wdl
+++ b/workflows/amr/run.wdl
@@ -636,19 +636,20 @@ task tsvToSam {
         python3 <<CODE
         import pandas as pd
         import pysam
+        import sys
 
         COLUMN_GENE_ID = "Reference Sequence_kma_amr"
         COLUMN_CONTIG_NAME = "Contig_contig_amr"
         OUTPUT_BAM = "contig_amr_report.sorted.bam"
 
-        # Create an empty BAM file if the SPADES assembly failed
+        # Create an empty BAM/BAI file if the SPADES assembly failed, then exit
         with open("~{contigs}") as f:
             first_line = f.readline()
             if first_line == ";ASSEMBLY FAILED\n":
                 output_bam = pysam.AlignmentFile(OUTPUT_BAM, "wb", reference_names=["NoGenes"], reference_lengths=[100])
                 output_bam.close()
                 pysam.index(OUTPUT_BAM)
-                return
+                sys.exit()
 
         # Create index to enable querying fasta file
         pysam.faidx("~{contigs}")

--- a/workflows/amr/run.wdl
+++ b/workflows/amr/run.wdl
@@ -641,6 +641,15 @@ task tsvToSam {
         COLUMN_CONTIG_NAME = "Contig_contig_amr"
         OUTPUT_BAM = "contig_amr_report.sorted.bam"
 
+        # Create an empty BAM file if the SPADES assembly failed
+        with open("~{contigs}") as f:
+            first_line = f.readline()
+            if first_line == ";ASSEMBLY FAILED\n":
+                output_bam = pysam.AlignmentFile(OUTPUT_BAM, "wb", reference_names=["NoGenes"], reference_lengths=[100])
+                output_bam.close()
+                pysam.index(OUTPUT_BAM)
+                return
+
         # Create index to enable querying fasta file
         pysam.faidx("~{contigs}")
         contigs_fasta = pysam.Fastafile("~{contigs}")


### PR DESCRIPTION
This PR fixes the bug encountered in CZID-7837.

When the SPADES assembly fails, we create a `contigs.fasta` file containing `;ASSEMBLY FAILED`, which is not a valid FASTA. This leads the `TsvToSam` step to fail when it tries to create an FAI index for `contigs.fasta`. Instead I'm checking for this special case and exiting the TsvToSam step early.

### Tests

* Tested on staging that the sample previously failing is no longer failing
* Also tested that samples that previously did not fail are still not failing