### PR TITLE
Fix bug in long-read-mngs filter clipped alignments

### DIFF
--- a/lib/bin/filter_clipped_alignments.py
+++ b/lib/bin/filter_clipped_alignments.py
@@ -1,6 +1,18 @@
 import csv
 import re
 import argparse
+import sys
+
+# the SAM file input has the full sequence which can be very long
+#   increase the csv field size limit to ensure they will fit
+_field_size_limit = sys.maxsize
+while True:
+    try:
+        csv.field_size_limit(_field_size_limit)
+        break
+    # if the size limit is two high make it one bit smaller and try again
+    except OverflowError:
+        _field_size_limit = int(_field_size_limit >> 1)
 
 front_pattern = re.compile(r"^\d+[SH]")
 end_pattern = re.compile(r"\d+[SH]$")


### PR DESCRIPTION
We were getting the following error on a user's sample from this script:

```
 _csv.Error: field larger than field limit (131072)
 ```

Based on [this](https://stackoverflow.com/questions/15063936/csv-error-field-larger-than-field-limit-131072) answer it looks like there is either a delimiter problem or the field is actually just too big. I checked the file in question and it does have a contig that long. That makes sense, contigs can be quite long. Also confirmed it worked with the size upgrade.