### PR TITLE
Fix fastp error if no reads after ercc filtering

### DIFF
--- a/workflows/short-read-mngs/Dockerfile
+++ b/workflows/short-read-mngs/Dockerfile
@@ -209,4 +209,6 @@ RUN pip3 install /tmp/idseq-dag && rm -rf /tmp/idseq-dag
 COPY --from=lib idseq_utils /tmp/idseq_utils
 RUN pip3 install /tmp/idseq_utils && rm -rf /tmp/idseq_utils
 
+COPY --from=lib /bin/raise_error /usr/local/bin/raise_error
+
 COPY --from=s3quilt /usr/lib/python3/dist-packages/s3quilt/ /usr/lib/python3/dist-packages/s3quilt/

--- a/workflows/short-read-mngs/host_filter.wdl
+++ b/workflows/short-read-mngs/host_filter.wdl
@@ -295,6 +295,10 @@ task ercc_bowtie2_filter {
 
     count=$((count / 4))
     jq --null-input --arg count "$count" '{"bowtie2_ercc_filtered_out":$count}' > 'bowtie2_ercc_filtered_out.count'
+    
+    if [[ "$count" -eq "0" ]]; then 
+      raise_error InsufficientReadsError "There was an insufficient number of reads in the sample after the host and quality filtering steps."
+    fi
 
     python3 - << 'EOF'
     import textwrap


### PR DESCRIPTION
* Fastp crashes if given an empty input file
* handles empty output from ercc bowtie step