### PR TITLE
pin dask version to a version that supports python 3.8

### DIFF
--- a/workflows/amr/requirements.txt
+++ b/workflows/amr/requirements.txt
@@ -11,3 +11,4 @@ pysam==0.16.0.1
 pytest==7.1.2
 requests==2.24.0
 seaborn==0.11.2
+dask==2023.5.0


### PR DESCRIPTION
* The latest version of dask doesn't support python3.8. This pins the version. 