### PR TITLE
Properly escape files with spaces

### DIFF
--- a/workflows/consensus-genome/run.wdl
+++ b/workflows/consensus-genome/run.wdl
@@ -1092,7 +1092,7 @@ task ZipOutputs {
         export TMPDIR=${TMPDIR:-/tmp}
 
         mkdir ${TMPDIR}/outputs
-        cp ~{sep=' ' outputFiles} ${TMPDIR}/outputs/
+        cp "~{sep='" "' outputFiles}" ${TMPDIR}/outputs/
         zip -r -j "~{prefix}"outputs.zip ${TMPDIR}/outputs/
     >>>
 

--- a/workflows/consensus-genome/run.wdl
+++ b/workflows/consensus-genome/run.wdl
@@ -309,7 +309,7 @@ task ValidateInput{
             raise_error InvalidInputFileError "An Oxford Nanopore pipeline run can only have one input file. Please upload a single file"
         fi 
 
-        for fastq in ~{sep=' ' fastqs}; do 
+        for fastq in "~{sep='" "' fastqs}"; do 
             # limit max # of reads to max_reads
             if [[ $fastq != *.gz ]]; then
                 filename=$(basename $fastq)".gz"


### PR DESCRIPTION
* we removed the block on spaces and parentheses in input files, so need to escape things properly