### PR TITLE
Add high level drug class to AMR output

### DIFF
--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -2,4 +2,4 @@
 
 set -euxo pipefail
 
-docker buildx build --build-context lib=lib "$@"
+docker buildx build --platform linux/amd64 --build-context lib=lib "$@"

--- a/workflows/amr/Dockerfile
+++ b/workflows/amr/Dockerfile
@@ -11,7 +11,7 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN curl -L https://github.com/bbuchfink/diamond/releases/download/v0.8.36/diamond-linux64.tar.gz | tar xz && mv diamond /usr/local/bin
 RUN curl -L http://www.unafold.org/download/oligoarrayaux-3.8.tar.gz | tar xz && cd oligoarrayaux-3.8/ && ./configure && make install 
 RUN curl -L https://github.com/samtools/samtools/releases/download/1.9/samtools-1.9.tar.bz2 | tar xj && cd samtools-1.9/ && make && mv samtools /usr/local/bin/
-RUN  curl -L https://github.com/lh3/bwa/releases/download/v0.7.17/bwa-0.7.17.tar.bz2 | tar xj && cd bwa-0.7.17/ && make &&  mv bwa /usr/local/bin/
+RUN curl -L https://github.com/lh3/bwa/releases/download/v0.7.17/bwa-0.7.17.tar.bz2 | tar xj && cd bwa-0.7.17/ && make &&  mv bwa /usr/local/bin/
 RUN curl -L  https://bitbucket.org/genomicepidemiology/kma/get/1.4.3.tar.gz | tar xz && cd genomicepidemiology-kma-47505a7dd4eb/ && make && mv kma kma_index kma_shm kma_update /usr/local/bin/
 
 RUN apt-get update && apt-get -y install  ncbi-blast+=2.9.0-2 prodigal=1:2.6.3-4 bamtools=2.5.1+dfsg-5build1 bowtie2=2.3.5.1-6build1 bedtools=2.27.1+dfsg-4ubuntu1
@@ -30,7 +30,7 @@ ARG SEQFU_VER="1.16.0"
 RUN curl -LO https://github.com/telatin/seqfu2/releases/download/v${SEQFU_VER}/SeqFu-v${SEQFU_VER}-Linux-x86_64.zip && \
     unzip SeqFu-v${SEQFU_VER}-Linux-x86_64.zip -d /usr/local/bin/
 
-RUN curl -LO https://github.com/shenwei356/seqkit/releases/download/v2.0.0/seqkit_linux_amd64.tar.gz && tar zxvf seqkit_linux_amd64.tar.gz \
+RUN curl -LO https://github.com/shenwei356/seqkit/releases/download/v2.4.0/seqkit_linux_amd64.tar.gz && tar zxvf seqkit_linux_amd64.tar.gz \
     && mv seqkit /usr/local/bin/ && rm seqkit_linux_amd64.tar.gz
 
 # load databases

--- a/workflows/amr/run.wdl
+++ b/workflows/amr/run.wdl
@@ -12,7 +12,7 @@ workflow amr {
         String sample_name
         String host_filtering_docker_image_id = "czid-short-read-mngs" # default local value
         File card_json = "s3://czid-public-references/card/2023-05-22/card.json"
-        File card_ontology = "s3://idseq-developers/lvreynoso/amr_v2/ontology/2023-06-13/ontology.json"
+        File card_ontology = "s3://czid-public-references/amr_v2/ontology/initial/ontology.json"
         File kmer_db = "s3://czid-public-references/card/2023-05-22/61_kmer_db.json"
         File amr_kmer_db = "s3://czid-public-references/card/2023-05-22/all_amr_61mers.txt"
         File wildcard_data = "s3://czid-public-references/card/2023-05-22/wildcard_database_v4.0.0.fasta"

--- a/workflows/amr/run.wdl
+++ b/workflows/amr/run.wdl
@@ -301,7 +301,8 @@ task RunResultsPerSample {
             result['drug_class'] = ';'.join(dc) if len(dc) > 0 else None
 
             hldc = get_high_level_classes(index)
-            result['high_level_drug_class'] = ';'.join(hldc) if len(hldc) > 0 else None
+            # Join classes with a semicolon and a space since we have a python list instead of a nice pandas union
+            result['high_level_drug_class'] = '; '.join(hldc) if len(hldc) > 0 else None
 
             rm = remove_na(set(sub_df['Resistance Mechanism_contig_amr']).union(set(sub_df['Resistance Mechanism_kma_amr'])))
             result['resistance_mechanism'] = ';'.join(rm) if len(rm) > 0 else None

--- a/workflows/amr/test/RunResultsPerSample/ontology.json
+++ b/workflows/amr/test/RunResultsPerSample/ontology.json
@@ -1,0 +1,148 @@
+{
+    "ArnT":
+    {
+        "label": "ArnT",
+        "accession": "3005053",
+        "description": "ArnT is involved in Cell Wall Biosynthesis, specifically 4-amino-4-deoxy-L-arabinose (Ara4N). It confers resistance to peptide antibiotics.",
+        "parentAccessions":
+        [
+            "3004269",
+            "3000622",
+            "3000624"
+        ],
+        "childrenAccessions":
+        [
+            "3005065"
+        ],
+        "highLevelDrugClasses":
+        [
+            "peptide antibiotic"
+        ],
+        "synonyms":
+        [
+            "ArnT"
+        ],
+        "dnaAccession": "FO834906.1",
+        "proteinAccession": "CDO12042.1",
+        "geneFamily": "pmr phosphoethanolamine transferase",
+        "drugClass": "peptide antibiotic"
+    },
+    "Staphylococcus aureus LmrS":
+    {
+        "label": "Staphylococcus aureus LmrS",
+        "accession": "3004572",
+        "description": "MFS transporters are secondary active transporters with single-polypeptide chains containing 400-600 amino acids that transport small solutes across the membrane by using electrochemical gradients. LmrS has 14 transmembrane helices and, when expressed in E. coli, is capable of extruding a variety of antibiotics inclinding linezolid, trimethoprim, florfenicol, chlorampheniocol, erythromycin, streptomycin, kanamycin, and fusidic acid.",
+        "parentAccessions":
+        [
+            "0010002",
+            "0000006",
+            "0000040",
+            "0000049",
+            "0000072",
+            "3000188",
+            "3000385",
+            "3000461"
+        ],
+        "childrenAccessions":
+        [],
+        "highLevelDrugClasses":
+        [
+            "macrolide antibiotic",
+            "aminoglycoside antibiotic",
+            "oxazolidinone antibiotic",
+            "diaminopyrimidine antibiotic",
+            "phenicol antibiotic"
+        ],
+        "synonyms":
+        [
+            "A0A3M7YRP9",
+            "A0A3P0BBR7",
+            "F6MF49",
+            "Saur_LmrS"
+        ],
+        "dnaAccession": "CP000046.1",
+        "proteinAccession": "AAW38464.1",
+        "geneFamily": "major facilitator superfamily (MFS) antibiotic efflux pump",
+        "drugClass": "aminoglycoside antibiotic;diaminopyrimidine antibiotic;macrolide antibiotic;oxazolidinone antibiotic;phenicol antibiotic"
+    },
+    "fosA5":
+    {
+        "label": "fosA5",
+        "accession": "3003209",
+        "description": "fosA5 is a fosfomycin resistance gene isolated from clinical strain of Escherichia coli E265. It is susceptible to amikacin, tetracycline and imipenem, and resistant to sulphonamide, cephalosporins, gentamicin, ciprofloxacin, chloramphenicol and streptomycin.",
+        "parentAccessions":
+        [
+            "3000133",
+            "0000036",
+            "3007382"
+        ],
+        "childrenAccessions":
+        [],
+        "highLevelDrugClasses":
+        [
+            "fluoroquinolone antibiotic",
+            "aminoglycoside antibiotic",
+            "phosphonic acid antibiotic"
+        ],
+        "synonyms":
+        [
+            "fosA5"
+        ],
+        "dnaAccession": "KP143090.1",
+        "proteinAccession": "AJE60855.1",
+        "geneFamily": "fosfomycin thiol transferase",
+        "drugClass": "aminoglycoside antibiotic;fluoroquinolone antibiotic;phosphonic acid antibiotic"
+    },
+    "norC":
+    {
+        "label": "norC",
+        "accession": "3007010",
+        "description": "NorC is a multidrug efflux pump in Staphylococcus aureus that confers resistance to fluoroquinolones and other structurally unrelated antibiotics like tetracycline. It shares 61% similarity with NorB, and is a structural homolog of Blt of Bacillus subtilis. Like NorA and NorB, NorC is regulated by mgrA, also known as NorR.",
+        "parentAccessions":
+        [
+            "0010002",
+            "3000391"
+        ],
+        "childrenAccessions":
+        [],
+        "highLevelDrugClasses":
+        [
+            "fluoroquinolone antibiotic",
+            "disinfecting agents and antiseptics"
+        ],
+        "synonyms":
+        [
+            "norC"
+        ],
+        "dnaAccession": "CP005288.1",
+        "proteinAccession": "AGP27106.1",
+        "geneFamily": "major facilitator superfamily (MFS) antibiotic efflux pump",
+        "drugClass": "disinfecting agents and antiseptics;fluoroquinolone antibiotic"
+    },
+    "smeB":
+    {
+        "label": "smeB",
+        "accession": "3003052",
+        "description": "smeB is the inner membrane multidrug exporter of the efflux complex smeABC in Stenotrophomonas maltophilia.",
+        "parentAccessions":
+        [
+            "3000748",
+            "3003050"
+        ],
+        "childrenAccessions":
+        [],
+        "highLevelDrugClasses":
+        [
+            "aminoglycoside antibiotic",
+            "beta-lactam antibiotic"
+        ],
+        "synonyms":
+        [
+            "smeB"
+        ],
+        "dnaAccession": "AF173226.1",
+        "proteinAccession": "AAD51345.1",
+        "geneFamily": "resistance-nodulation-cell division (RND) antibiotic efflux pump",
+        "drugClass": "aminoglycoside antibiotic;cephalosporin;cephamycin;penam"
+    }
+}

--- a/workflows/amr/test/test_wdl.py
+++ b/workflows/amr/test/test_wdl.py
@@ -46,6 +46,7 @@ class TestAMR(WDLTestCase):
         inputs = {
             "sample_name": "sample",
             "gene_coverage": relpath("RunResultsPerSample", "gene_coverage.tsv"),
+            "card_ontology": relpath("RunResultsPerSample", "ontology.json"),
             "kma_species_output": relpath(
                 "RunResultsPerSample", "sr_species_report_61mer_analysis.gene.txt"
             ),


### PR DESCRIPTION
Adds a new input to the AMR workflow and the RunResultsPerSample task within it for a json file with ontology information. Queries the json file for high level drug classes for a given gene name and adds them in a new column in `primary_AMR_report.tsv`.

Results from a successful run:
<img width="1260" alt="Screenshot 2023-07-07 at 14 23 10" src="https://github.com/chanzuckerberg/czid-workflows/assets/24234461/b758e761-c7f5-48bb-aadd-b33f0d7bb7b2">

After I made this screenshot I modified the `.join` call so that high level drug classes would have a space after each semicolon, like in the drug_class column.

### Notes
A previous commit added a call to `seqkit` but used flags found in a later version than the one installed. I updated the `seqkit` version in the amr dockerfile so the expected behavior would happen.