### PR TITLE
Handle case where gene entry in ontology has no HLDC

### DIFF
--- a/workflows/amr/run.wdl
+++ b/workflows/amr/run.wdl
@@ -374,7 +374,7 @@ task RunResultsPerSample {
         final_df = final_df[["sample_name", "gene_family", "drug_class", "high_level_drug_class", "resistance_mechanism", "model_type", "num_contigs",
                              "cutoff", "contig_coverage_breadth", "contig_percent_id", "contig_species", "num_reads", "read_gene_id", "read_coverage_breadth", "read_coverage_depth", "read_species"]]
         final_df.sort_index(inplace=True)
-        final_df.dropna(subset=['drug_class', 'high_level_drug_class'], inplace=True)
+        final_df.dropna(subset=['drug_class'], inplace=True)
         final_df.to_csv("primary_AMR_report.tsv", sep='\t', index_label="gene_name")
 
 

--- a/workflows/amr/run.wdl
+++ b/workflows/amr/run.wdl
@@ -286,6 +286,8 @@ task RunResultsPerSample {
         def get_high_level_classes(gene_name):
             if gene_name not in ontology:
                 return []
+            if 'highLevelDrugClasses' not in ontology[gene_name]:
+                return []
             return ontology[gene_name]['highLevelDrugClasses']
 
         this_list = list(set(df['ARO_overall']))

--- a/workflows/amr/test/RunResultsPerSample/ontology.json
+++ b/workflows/amr/test/RunResultsPerSample/ontology.json
@@ -105,7 +105,7 @@
         ],
         "childrenAccessions":
         [],
-        "highLevelDrugClasses":
+        "highLevelDrugClasses is somehow missing from this entry":
         [
             "fluoroquinolone antibiotic",
             "disinfecting agents and antiseptics"
@@ -119,7 +119,7 @@
         "geneFamily": "major facilitator superfamily (MFS) antibiotic efflux pump",
         "drugClass": "disinfecting agents and antiseptics;fluoroquinolone antibiotic"
     },
-    "smeB":
+    "smeB should not be found":
     {
         "label": "smeB",
         "accession": "3003052",


### PR DESCRIPTION
CZID-8052

Handles the case where a gene has an entry in the ontology file, but the gene's entry is missing the key `'highLevelDrugClasses'`.

Modifies test data to take this case (as well as a missing gene entry in the ontology file) into account.

No longer drops rows without a `high_level_drug_class` entry.