### PR TITLE
Use drug class instead of gene name to query for high level class

### DIFF
--- a/workflows/amr/run.wdl
+++ b/workflows/amr/run.wdl
@@ -283,11 +283,14 @@ task RunResultsPerSample {
             return([i for i in set_list if i == i])
 
         ontology = json.load(open("~{card_ontology}"))
-        def get_high_level_classes(drug_classes):
-            high_level_classes = []
+        def get_high_level_classes(drug_classes_union):
+            drug_classes = set()
+            for drug_class_string in drug_classes_union:
+                drug_classes |= set(drug_class_string.split('; '))
+            high_level_classes = set()
             for drug_class in drug_classes:
                 if drug_class in ontology:
-                    high_level_classes.extend(ontology[drug_class]['highLevelDrugClasses'])
+                    high_level_classes |= set(ontology[drug_class]['highLevelDrugClasses'])
             return high_level_classes
 
         this_list = list(set(df['ARO_overall']))

--- a/workflows/amr/run.wdl
+++ b/workflows/amr/run.wdl
@@ -283,7 +283,7 @@ task RunResultsPerSample {
             return([i for i in set_list if i == i])
 
         ontology = json.load(open("~{card_ontology}"))
-        def get_high_level_classes(drug_classes: list[str]):
+        def get_high_level_classes(drug_classes):
             high_level_classes = []
             for drug_class in drug_classes:
                 if drug_class in ontology:

--- a/workflows/amr/run.wdl
+++ b/workflows/amr/run.wdl
@@ -283,12 +283,12 @@ task RunResultsPerSample {
             return([i for i in set_list if i == i])
 
         ontology = json.load(open("~{card_ontology}"))
-        def get_high_level_classes(gene_name):
-            if gene_name not in ontology:
-                return []
-            if 'highLevelDrugClasses' not in ontology[gene_name]:
-                return []
-            return ontology[gene_name]['highLevelDrugClasses']
+        def get_high_level_classes(drug_classes: list[str]):
+            high_level_classes = []
+            for drug_class in drug_classes:
+                if drug_class in ontology:
+                    high_level_classes.extend(ontology[drug_class]['highLevelDrugClasses'])
+            return high_level_classes
 
         this_list = list(set(df['ARO_overall']))
         result_df = {}
@@ -305,7 +305,7 @@ task RunResultsPerSample {
             dc = remove_na(set(sub_df['Drug Class_contig_amr']).union(set(sub_df['Drug Class_kma_amr'])))
             result['drug_class'] = ';'.join(dc) if len(dc) > 0 else None
 
-            hldc = get_high_level_classes(index)
+            hldc = get_high_level_classes(dc)
             # Join classes with a semicolon and a space since we have a python list instead of a nice pandas union
             result['high_level_drug_class'] = '; '.join(hldc) if len(hldc) > 0 else None
 

--- a/workflows/amr/run.wdl
+++ b/workflows/amr/run.wdl
@@ -290,7 +290,7 @@ task RunResultsPerSample {
             high_level_classes = set()
             for drug_class in drug_classes:
                 if drug_class in ontology:
-                    high_level_classes |= set(ontology[drug_class]['highLevelDrugClasses'])
+                    high_level_classes |= set(ontology[drug_class].get('highLevelDrugClasses', []))
             return high_level_classes
 
         this_list = list(set(df['ARO_overall']))

--- a/workflows/amr/run.wdl
+++ b/workflows/amr/run.wdl
@@ -283,9 +283,9 @@ task RunResultsPerSample {
             return([i for i in set_list if i == i])
 
         ontology = json.load(open("~{card_ontology}"))
-        def get_high_level_classes(drug_classes_union):
+        def get_high_level_classes(drug_class_string_list):
             drug_classes = set()
-            for drug_class_string in drug_classes_union:
+            for drug_class_string in drug_class_string_list:
                 drug_classes |= set(drug_class_string.split('; '))
             high_level_classes = set()
             for drug_class in drug_classes:

--- a/workflows/amr/test/RunResultsPerSample/ontology.json
+++ b/workflows/amr/test/RunResultsPerSample/ontology.json
@@ -41,7 +41,9 @@
             "dummy"
         ],
         "highLevelDrugClasses":
-        [],
+        [
+            "peptide antibiotic"
+        ],
         "synonyms":
         []
     },
@@ -97,7 +99,9 @@
             ""
         ],
         "highLevelDrugClasses":
-        [],
+        [
+            "phenicol antibiotic"
+        ],
         "synonyms":
         [
             "phenicol"
@@ -117,7 +121,9 @@
             "dummy"
         ],
         "highLevelDrugClasses":
-        [],
+        [
+            "oxazolidinone antibiotic"
+        ],
         "synonyms":
         []
     },
@@ -135,7 +141,9 @@
             "dummy"
         ],
         "highLevelDrugClasses":
-        [],
+        [
+            "macrolide antibiotic"
+        ],
         "synonyms":
         []
     },
@@ -153,7 +161,9 @@
             "dummy"
         ],
         "highLevelDrugClasses":
-        [],
+        [
+            "aminoglycoside antibiotic"
+        ],
         "synonyms":
         []
     },
@@ -176,7 +186,9 @@
             "3001218"
         ],
         "highLevelDrugClasses":
-        [],
+        [
+            "diaminopyrimidine antibiotic"
+        ],
         "synonyms":
         [
             "diaminopyrimidine"
@@ -224,7 +236,9 @@
             "dummy"
         ],
         "highLevelDrugClasses":
-        [],
+        [
+            "fluoroquinolone antibiotic"
+        ],
         "synonyms":
         [
             "fluoroquinolone",
@@ -245,7 +259,9 @@
             "dummy"
         ],
         "highLevelDrugClasses":
-        [],
+        [
+            "phosphonic acid antibiotic"
+        ],
         "synonyms":
         []
     },

--- a/workflows/amr/test/RunResultsPerSample/ontology.json
+++ b/workflows/amr/test/RunResultsPerSample/ontology.json
@@ -27,6 +27,24 @@
         "geneFamily": "pmr phosphoethanolamine transferase",
         "drugClass": "peptide antibiotic"
     },
+    "peptide antibiotic":
+    {
+        "label": "peptide antibiotic",
+        "accession": "3000053",
+        "description": "Peptide antibiotics have a wide range of antibacterial mechanisms, depending on the amino acids that make up the antibiotic, although most act to disrupt the cell membrane in some manner. Subclasses of peptide antibiotics can include additional sidechains of other types, such as lipids in the case of the lipopeptide antibiotics.",
+        "parentAccessions":
+        [
+            "1000003"
+        ],
+        "childrenAccessions":
+        [
+            "dummy"
+        ],
+        "highLevelDrugClasses":
+        [],
+        "synonyms":
+        []
+    },
     "Staphylococcus aureus LmrS":
     {
         "label": "Staphylococcus aureus LmrS",
@@ -65,6 +83,105 @@
         "geneFamily": "major facilitator superfamily (MFS) antibiotic efflux pump",
         "drugClass": "aminoglycoside antibiotic;diaminopyrimidine antibiotic;macrolide antibiotic;oxazolidinone antibiotic;phenicol antibiotic"
     },
+    "phenicol antibiotic":
+    {
+        "label": "phenicol antibiotic",
+        "accession": "3000387",
+        "description": "Phenicols are broad spectrum bacteriostatic antibiotics acting on bacterial protein synthesis. More specifically, the phenicols block peptide elongation by binding to the peptidyltansferase centre of the 70S ribosome.",
+        "parentAccessions":
+        [
+            "1000003"
+        ],
+        "childrenAccessions":
+        [
+            ""
+        ],
+        "highLevelDrugClasses":
+        [],
+        "synonyms":
+        [
+            "phenicol"
+        ]
+    },
+    "oxazolidinone antibiotic":
+    {
+        "label": "oxazolidinone antibiotic",
+        "accession": "3000079",
+        "description": "Oxazolidinones are a class of synthetic antibiotics discovered the the 1980s.  They inhibit protein synthesis by binding to domain V of the 23S rRNA of the 50S subunit of bacterial ribosomes.  Linezolid is the only member of this class currently in clinical use.",
+        "parentAccessions":
+        [
+            "1000003"
+        ],
+        "childrenAccessions":
+        [
+            "dummy"
+        ],
+        "highLevelDrugClasses":
+        [],
+        "synonyms":
+        []
+    },
+    "macrolide antibiotic":
+    {
+        "label": "macrolide antibiotic",
+        "accession": "0000000",
+        "description": "Macrolides are a group of drugs (typically antibiotics) that have a large macrocyclic lactone ring of 12-16 carbons to which one or more deoxy sugars, usually cladinose and desosamine, may be attached. Macrolides bind to the 50S-subunit of bacterial ribosomes, inhibiting the synthesis of vital proteins.",
+        "parentAccessions":
+        [
+            "1000003"
+        ],
+        "childrenAccessions":
+        [
+            "dummy"
+        ],
+        "highLevelDrugClasses":
+        [],
+        "synonyms":
+        []
+    },
+    "aminoglycoside antibiotic":
+    {
+        "label": "aminoglycoside antibiotic",
+        "accession": "0000016",
+        "description": "Aminoglycosides are a group of antibiotics that are mostly effective against Gram-negative bacteria. These molecules consist of aminated sugars attached to a dibasic cyclitol. Aminoglycosides work by binding to the bacterial 30S ribosomal subunit (some work by binding to the 50S subunit), inhibiting the translocation of the peptidyl-tRNA from the A-site to the P-site and also causing misreading of mRNA, leaving the bacterium unable to synthesize proteins vital to its growth.",
+        "parentAccessions":
+        [
+            "1000003"
+        ],
+        "childrenAccessions":
+        [
+            "dummy"
+        ],
+        "highLevelDrugClasses":
+        [],
+        "synonyms":
+        []
+    },
+    "diaminopyrimidine antibiotic":
+    {
+        "label": "diaminopyrimidine antibiotic",
+        "accession": "3000171",
+        "description": "Diaminopyrimidines are a class of organic compounds containing a pyrimidine ring substituted by two amine groups.  They are inhibitors of dihydrofolate reductase, an enzyme critical for DNA synthesis.",
+        "parentAccessions":
+        [
+            "1000003"
+        ],
+        "childrenAccessions":
+        [
+            "3000188",
+            "3000269",
+            "3000284",
+            "3000337",
+            "3000745",
+            "3001218"
+        ],
+        "highLevelDrugClasses":
+        [],
+        "synonyms":
+        [
+            "diaminopyrimidine"
+        ]
+    },
     "fosA5":
     {
         "label": "fosA5",
@@ -93,6 +210,45 @@
         "geneFamily": "fosfomycin thiol transferase",
         "drugClass": "aminoglycoside antibiotic;fluoroquinolone antibiotic;phosphonic acid antibiotic"
     },
+    "fluoroquinolone antibiotic":
+    {
+        "label": "fluoroquinolone antibiotic",
+        "accession": "0000001",
+        "description": "The fluoroquinolones are a family of synthetic broad-spectrum antibiotics that are 4-quinolone-3-carboxylates. These compounds interact with topoisomerase II (DNA gyrase) to disrupt bacterial DNA replication, damage DNA, and cause cell death.",
+        "parentAccessions":
+        [
+            "1000003"
+        ],
+        "childrenAccessions":
+        [
+            "dummy"
+        ],
+        "highLevelDrugClasses":
+        [],
+        "synonyms":
+        [
+            "fluoroquinolone",
+            "quinolone"
+        ]
+    },
+    "phosphonic acid antibiotic":
+    {
+        "label": "phosphonic acid antibiotic",
+        "accession": "3007149",
+        "description": "A group of antibiotics derived from phosphonic acids.",
+        "parentAccessions":
+        [
+            "1000003"
+        ],
+        "childrenAccessions":
+        [
+            "dummy"
+        ],
+        "highLevelDrugClasses":
+        [],
+        "synonyms":
+        []
+    },
     "norC":
     {
         "label": "norC",
@@ -119,7 +275,7 @@
         "geneFamily": "major facilitator superfamily (MFS) antibiotic efflux pump",
         "drugClass": "disinfecting agents and antiseptics;fluoroquinolone antibiotic"
     },
-    "smeB should not be found":
+    "smeB":
     {
         "label": "smeB",
         "accession": "3003052",
@@ -144,5 +300,65 @@
         "proteinAccession": "AAD51345.1",
         "geneFamily": "resistance-nodulation-cell division (RND) antibiotic efflux pump",
         "drugClass": "aminoglycoside antibiotic;cephalosporin;cephamycin;penam"
+    },
+    "cephalosporin":
+    {
+        "label": "cephalosporin",
+        "accession": "0000032",
+        "description": "Cephalosporins are a class of beta-lactam antibiotics, containing the beta-lactam ring fused with a dihydrothiazolidine ring. Together with cephamycins they belong to a sub-group called cephems. Cephalosporin are bactericidal, and act by inhibiting the synthesis of the peptidoglycan layer of bacterial cell walls. The peptidoglycan layer is important for cell wall structural integrity, especially in Gram-positive organisms.",
+        "parentAccessions":
+        [
+            "3000276"
+        ],
+        "childrenAccessions":
+        [
+            "dummy"
+        ],
+        "highLevelDrugClasses":
+        [
+            "beta-lactam antibiotic"
+        ],
+        "synonyms":
+        []
+    },
+    "cephamycin":
+    {
+        "label": "cephamycin",
+        "accession": "0000044",
+        "description": "Cephamycins are a group of beta-lactam antibiotics, very similar to cephalosporins. Together with cephalosporins, they form a sub-group of antibiotics known as cephems. Cephamycins are bactericidal, and act by inhibiting the synthesis of the peptidoglycan layer of bacterial cell walls. The peptidoglycan layer is important for cell wall structural integrity, especially in Gram-positive organisms. The 7-alpha-methoxy group increases resistance to beta-lactamases.",
+        "parentAccessions":
+        [
+            "3000276"
+        ],
+        "childrenAccessions":
+        [
+            "dummy"
+        ],
+        "highLevelDrugClasses":
+        [
+            "beta-lactam antibiotic"
+        ],
+        "synonyms":
+        []
+    },
+    "penam is missing for some reason":
+    {
+        "label": "penam",
+        "accession": "3000008",
+        "description": "Penams are a group of antibiotics derived from Penicillium fungi that share a skeleton beta-lactam moiety fused with a thiazolidine ring. This is the most defining feature of penicillins. Penicillin antibiotics are historically significant because they are the first drugs that were effective against many previously serious diseases such as syphilis and Staphylococcus infections. Penicillins are still widely used today, though many types of bacteria are now resistant. All penicillins are beta-lactam antibiotics in the penam sub-group, and are used in the treatment of bacterial infections caused by susceptible, usually Gram-positive, organisms.",
+        "parentAccessions":
+        [
+            "3000007"
+        ],
+        "childrenAccessions":
+        [
+            "dummy"
+        ],
+        "highLevelDrugClasses":
+        [
+            "beta-lactam antibiotic"
+        ],
+        "synonyms":
+        []
     }
 }


### PR DESCRIPTION
Obtains the names of high-level drug classes for each gene by using the gene's drug class to query the ontology file.

Sample output:
<img width="551" alt="Screenshot 2023-07-17 at 17 07 33" src="https://github.com/chanzuckerberg/czid-workflows/assets/24234461/fd7f1ad6-962b-4a3f-bca2-53a4b84779cb">
