### PR TITLE
[CZID-8579] Fix typo

### DIFF
--- a/workflows/phylotree-ng/python_steps/fetch_ncbi_metadata.py
+++ b/workflows/phylotree-ng/python_steps/fetch_ncbi_metadata.py
@@ -57,7 +57,7 @@ def get_accession_metadata(accession_id: str):
                     accession_metadata[key] = entry.find('GBQualifier_value').text
         return accession_metadata
     except Exception as e:
-        logging.warn(f"Fetching metadata for accession ID {accession_id} failed with error: {e}", exec_info=True)
+        logging.warn(f"Fetching metadata for accession ID {accession_id} failed with error: {e}", exc_info=True)
         return accession_metadata
 
 


### PR DESCRIPTION
Fix a small typo that causes the warning log to error out. [Docs](https://docs.python.org/3/library/logging.html#logging.LogRecord)

```
"TypeError: _log() got an unexpected keyword argument 'exec_info'"
```