### PR TITLE
[CZID-8624] Enforce and automate changelog updates

### DIFF
--- a/.github/workflows/release_workflows.yml
+++ b/.github/workflows/release_workflows.yml
@@ -9,7 +9,7 @@ on:
         description: major, minor, or patch
         default: patch
       release_notes:
-        description: A text message summarizing the changes in this release
+        description: A text message summarizing the changes in this release, only used for branch releases
 
 env:
   GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/wdl-ci.yml
+++ b/.github/workflows/wdl-ci.yml
@@ -50,6 +50,34 @@ jobs:
       - id: list_dirs
         run: echo "matrix=$(./scripts/diff-workflows.sh |jq -cnR '[inputs|select(length>0)]')" >> $GITHUB_OUTPUT
 
+  check-changelog:
+    runs-on: ubuntu-22.04
+    needs: list-workflow-dirs
+    if: ${{ needs['list-workflow-dirs'].outputs.matrix != '[]' && needs['list-workflow-dirs'].outputs.matrix != '' }}
+    strategy:
+      matrix:
+        workflow_dir: ${{fromJson(needs['list-workflow-dirs'].outputs.matrix)}}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check for Changelog Update
+        run: |
+          if git diff --name-only origin/main...HEAD | grep 'CHANGELOG.md' > /dev/null; then
+            echo "Changelog updated."
+          else
+            echo "::error::Changelog not updated!"
+            exit 1
+          fi
+      - name: Check for Changelog Format
+        run: |
+          # Count the number of occurrences of the workflow-unreleased string in the changelog
+          COUNT=$(grep -c "^### ${{ matrix.workflow_dir }}-unreleased" CHANGELOG.md)
+          if [ "$COUNT" -eq "1" ]; then
+            echo "Workflow unreleased version only appears once in changelog."
+          else
+            echo "::error::Workflow has multiple unreleased versions in changelog"
+            exit 1
+          fi
+
   wdl-ci:
     runs-on: ubuntu-22.04
     needs: list-workflow-dirs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ To add clarity for users it is [recommended](https://keepachangelog.com/en/1.0.0
 
 In addition, if a modification is made that may affect the results of a pipeline run, we suggest using noting the `[Pipeline Change]` as well as including the specific change that was made, the predicted result to the output. 
 
+When developing add changes to an `-unreleased` entry for your workflow: i.e. `short-read-mngs-unreleased`. Make sure to use the same markdown heading level `###`. If one does not exist, create one, otherwise update the existing.
+
 ## Changelog
 
 ### short-read-mngs-v7.1.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ To add clarity for users it is [recommended](https://keepachangelog.com/en/1.0.0
 
 In addition, if a modification is made that may affect the results of a pipeline run, we suggest using noting the `[Pipeline Change]` as well as including the specific change that was made, the predicted result to the output. 
 
-### Unreleased
+## Changelog
 
 ### short-read-mngs-v7.1.11
 - Reduce memory usage of generating the alignment viz

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -28,19 +28,30 @@ else
     exit 1
 fi
 
+<<<<<<< Updated upstream
 # Fix until we can update this script to follow semantic versioning
 if [[ $WORKFLOW_NAME == amr ]]; then
     TAG="amr-v1.3.0"
 fi
+=======
+TAG_MSG=$(mktemp)
+>>>>>>> Stashed changes
 
 if [[ $( git branch --show-current) != "main" ]]; then 
     COMMIT=$(git rev-parse --short HEAD)
     TAG=$TAG"-$COMMIT"
+    echo "# Changes for ${TAG} ($(date +%Y-%m-%d))" > $TAG_MSG
+    echo "$RELEASE_NOTES" >> $TAG_MSG
+else
+    git config --local user.email "action@github.com"
+    git config --local user.name "GitHub Action"
+    sed -i "s/^### \$WORKFLOW_NAME-unreleased/^### \$TAG/g" CHANGELOG.md
+    git add $CHANGELOG_FILE
+    git commit -m "Update changelog for version $TAG"
+    git push origin main
+    awk "/^### $TAG/,/^### /{if (!/^### $TAG/ && !/^### /) print}" "$FILE_PATH" >> $TAG_MSG
 fi
 
-TAG_MSG=$(mktemp)
-echo "# Changes for ${TAG} ($(date +%Y-%m-%d))" > $TAG_MSG
-echo "$RELEASE_NOTES" >> $TAG_MSG
 git log --pretty=format:%s ${OLD_TAG}..HEAD >> $TAG_MSG || true
 if ! git config --get user.name ; then
     git config user.name "CZ ID release action triggered by ${GITHUB_ACTOR:-$(whoami)}"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -43,10 +43,10 @@ else
     git config --local user.email "action@github.com"
     git config --local user.name "GitHub Action"
     sed -i "s/^### \$WORKFLOW_NAME-unreleased/^### \$TAG/g" CHANGELOG.md
-    git add $CHANGELOG_FILE
+    git add "CHANGELOG.md"
     git commit -m "Update changelog for version $TAG"
     git push origin main
-    awk "/^### $TAG/,/^### /{if (!/^### $TAG/ && !/^### /) print}" "$FILE_PATH" >> $TAG_MSG
+    sed -n "/^### $TAG/,/^### /p" "CHANGELOG.md" | sed '1d;$d' >> $TAG_MSG
 fi
 
 git log --pretty=format:%s ${OLD_TAG}..HEAD >> $TAG_MSG || true

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -28,14 +28,11 @@ else
     exit 1
 fi
 
-<<<<<<< Updated upstream
 # Fix until we can update this script to follow semantic versioning
 if [[ $WORKFLOW_NAME == amr ]]; then
     TAG="amr-v1.3.0"
 fi
-=======
 TAG_MSG=$(mktemp)
->>>>>>> Stashed changes
 
 if [[ $( git branch --show-current) != "main" ]]; then 
     COMMIT=$(git rev-parse --short HEAD)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -42,7 +42,7 @@ if [[ $( git branch --show-current) != "main" ]]; then
 else
     git config --local user.email "action@github.com"
     git config --local user.name "GitHub Action"
-    sed -i "s/^### \$WORKFLOW_NAME-unreleased/^### \$TAG/g" CHANGELOG.md
+    sed -i "s/^### $WORKFLOW_NAME-unreleased/### $TAG/g" "CHANGELOG.md"
     git add "CHANGELOG.md"
     git commit -m "Update changelog for version $TAG"
     git push origin main


### PR DESCRIPTION
This enforces developers update a changelog and automates the versioning of the changelog. When developing developers can now update the changelog with unreleased notes like:

```
### short-read-mngs-unreleased
- my notes
```

If they don't, the PR check fails. At deploy time the correct version is automatically filled in instead of unreleased.