### PR TITLE
case insensitive phage match

### DIFF
--- a/workflows/index-generation/generate_lineage_csvs.py
+++ b/workflows/index-generation/generate_lineage_csvs.py
@@ -38,6 +38,7 @@ _versioning_fieldnames = [
     "updated_at",
 ]
 
+phage_search_string = re.compile(r"\bphage\b", re.IGNORECASE)
 
 # We label as 'phage' all of the prokaryotic (bacterial and archaeal) virus families
 # listed here: https://en.wikipedia.org/wiki/Bacteriophage
@@ -142,7 +143,7 @@ def generate_taxon_lineage_names(
             new_row["is_phage"] = (
                 1
                 if family_name in PHAGE_FAMILIES_NAMES
-                or re.search(r"\bphage\b", tax_name)
+                or phage_search_string.search(tax_name)
                 else 0
             )
             writer.writerow(new_row)

--- a/workflows/index-generation/test/test_files/names_file_test.csv
+++ b/workflows/index-generation/test/test_files/names_file_test.csv
@@ -17,7 +17,7 @@ tax_id,name_txt,name_txt_common
 197911,Alphainfluenzavirus,
 11320,Influenza A virus,
 2732396,Orthornavirae,
-28368,Corynebacterium diphtheriae phage,
+28368,Corynebacterium diphtheriae Phage,
 -600,,
 -500,,
 -400,,


### PR DESCRIPTION
Previously we were only matching against "phage" but we want to count words like "Phage" as phage viruses as well. Uses `re.IGNORECASE` for case-insensitive full word match.