### PR TITLE
Fix issue with RunRedup hanging on large duplicate cluster sizes

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -28,10 +28,6 @@ else
     exit 1
 fi
 
-if [[ $WORKFLOW_NAME == amr ]]; then
-    TAG="amr-v1.3.2-patch-grephang"
-fi
-
 if [[ $( git branch --show-current) != "main" ]]; then 
     COMMIT=$(git rev-parse --short HEAD)
     TAG=$TAG"-$COMMIT"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -28,6 +28,10 @@ else
     exit 1
 fi
 
+if [[ $WORKFLOW_NAME == amr ]]; then
+    TAG="amr-v1.3.2-patch-grephang"
+fi
+
 if [[ $( git branch --show-current) != "main" ]]; then 
     COMMIT=$(git rev-parse --short HEAD)
     TAG=$TAG"-$COMMIT"

--- a/workflows/amr/README.md
+++ b/workflows/amr/README.md
@@ -4,6 +4,17 @@ CZ ID's AMR workflow implements the [Resistance Gene Identifier (RGI)](https://g
 
 # Changelog
 
+## 1.3.3 - Tentative
+
+### Fixed
+
+- Fixes an issue where the `RunRedup` task would hang when processing samples with large amounts of duplicate sequence data. `grep` has been replaced with `awk` when processing the duplicate cluster sizes tsv and clusters csv files.
+- Fixes an issue where `RunRedup` output fasta files were inconsistently named.
+
+### Changed
+
+- Harmonizes file naming in `RunRedup` to use underscores (_) instead of dashes (-).
+
 ## 1.3.2 - 2023-11-21
 
 ### Fixed


### PR DESCRIPTION
[CZID-8963](https://czi-tech.atlassian.net/browse/CZID-8963?atlOrigin=eyJpIjoiZjBiYjgxMzg0OGE2NDZhMWFmODc5MTg5Y2RmODQ2ZGYiLCJwIjoiaiJ9)

* Fixes an issue where the RunRedup task would hang when processing samples with large amounts of duplicate sequence data. `grep` has been replaced with `awk` when processing the duplicate cluster sizes tsv and clusters csv files.
* Fixes an issue where RunRedup output fasta files were inconsistently named
* Harmonizes file naming in RunRedup to use underscores (`_`) instead of dashes (`-`).

[CZID-8963]: https://czi-tech.atlassian.net/browse/CZID-8963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ