### PR TITLE
Pin goimports and gopy versions

### DIFF
--- a/workflows/short-read-mngs/Dockerfile
+++ b/workflows/short-read-mngs/Dockerfile
@@ -12,9 +12,9 @@ RUN /go/bin/go version
 WORKDIR /go/src/s3quilt
 COPY --from=lib s3quilt/go.mod s3quilt/go.sum s3quilt/s3quilt.go ./
 
-RUN go get golang.org/x/tools/cmd/goimports
+RUN go get golang.org/x/tools/cmd/goimports@v0.2.0
 RUN go install golang.org/x/tools/cmd/goimports
-RUN go get github.com/go-python/gopy
+RUN go get github.com/go-python/gopy@v0.4.4
 RUN go install github.com/go-python/gopy
 
 RUN pip3 install pybindgen setuptools wheel


### PR DESCRIPTION
Fixes an issue where new builds of the short-read-mngs Docker image fail if they aren't using cached versions of the s3quilt stage due to updated dependencies in the latest versions of goimports and gopy.