### PR TITLE
Migrate the metrics code in consensus_genome_coverage_service.rb to CG workflow

### DIFF
--- a/workflows/consensus-genome/run.wdl
+++ b/workflows/consensus-genome/run.wdl
@@ -1065,8 +1065,6 @@ task ComputeStats {
         # migrated metrics from Ruby app
         MAX_NUM_BINS = 500
 
-        stats = {"sample_name": "~{sample}"}
-
         stats["coverage_breadth"] = sum(1 for depth in depths if depth > 0) / len(depths)
         stats["max_aligned_length"] = len(depths)
         stats["total_length"] = len(depths)


### PR DESCRIPTION
[CZID-8775](https://czi-tech.atlassian.net/browse/CZID-8775?atlOrigin=eyJpIjoiY2YzYTMwZWNjYTc5NDYzYjhiZjlkYWE0ZWVmN2EzMGYiLCJwIjoiaiJ9)

[CZID-8775]: https://czi-tech.atlassian.net/browse/CZID-8775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Replaces the code found in the webapp [consensus_genome_coverage_service.rb](https://github.com/chanzuckerberg/czid-web/blob/main/app/services/consensus_genome_coverage_service.rb). Since the `coverage_depth` variable calculated in the webapp is already calculated in the CG workflow as `depth_avg` in the stats.json file output by compute stats, this is omitted. All other calculations are appended to stats.json.