### PR TITLE
[CZID-9425] Use AMR docker image for AMR RunSpades

### DIFF
--- a/workflows/amr/Dockerfile
+++ b/workflows/amr/Dockerfile
@@ -23,6 +23,11 @@ RUN pip3 install -r requirements.txt
 # RGI version 6.0.3
 RUN pip3 install git+https://github.com/lvreynoso/rgi.git@a14f8dd5457a6220a06024b6aebd05e8cb6181d7
 
+# Install SPAdes
+RUN curl -LO https://github.com/ablab/spades/releases/download/v3.11.1/SPAdes-3.11.1-Linux.tar.gz && \
+    tar -xzf SPAdes-3.11.1-Linux.tar.gz && \
+    ln -s /SPAdes-3.11.1-Linux/bin/spades.py /usr/local/bin/spades.py
+
 # Install seqfu (used for interleaving input files)
 ARG SEQFU_VER="1.16.0"
 RUN curl -LO https://github.com/telatin/seqfu2/releases/download/v${SEQFU_VER}/SeqFu-v${SEQFU_VER}-Linux-x86_64.zip && \
@@ -38,5 +43,5 @@ RUN curl -LO https://czid-public-references.s3.us-west-2.amazonaws.com/card/2023
         --card_annotation card_database_v3.2.6.fasta \
         -i card.json 
 
-
+COPY --from=lib /bin/log_assembly_fail.py /usr/local/bin/log_assembly_fail.py
 COPY empty-main-header.txt /tmp/empty-main-header.txt 

--- a/workflows/amr/README.md
+++ b/workflows/amr/README.md
@@ -4,10 +4,11 @@ CZ ID's AMR workflow implements the [Resistance Gene Identifier (RGI)](https://g
 
 # Changelog
 
-## 1.3.3 - 2024-02-23
+## 1.4.0 - 2024-02-26
 
 ### Added
 
+- Adds SPAdes 3.11.1 to the AMR docker image.
 - Adds a script to collect information from SPAdes logs when no contigs are assembled in RunSpades.
 
 ### Fixed
@@ -17,6 +18,7 @@ CZ ID's AMR workflow implements the [Resistance Gene Identifier (RGI)](https://g
 
 ### Changed
 
+- `RunSpades` now uses the container specified in `docker_image_id` instead of `host_filtering_docker_image_id`.
 - Harmonizes file naming in `RunRedup` to use underscores (_) instead of dashes (-).
 - Now uses [a fork](https://github.com/lvreynoso/rgi/commit/a14f8dd5457a6220a06024b6aebd05e8cb6181d7) of rgi version 6.0.3, with changes to fix an issue with parsing BAM files. Previously the AMR workflow used a fork of rgi version 6.0.0.
 

--- a/workflows/amr/run.wdl
+++ b/workflows/amr/run.wdl
@@ -61,7 +61,7 @@ workflow amr {
             input:
             reduplicated_reads = RunRedupRaw.redups_fa,
             min_contig_length = min_contig_length,
-            docker_image_id = host_filtering_docker_image_id,
+            docker_image_id = docker_image_id,
         }
     }
 

--- a/workflows/amr/test/test_wdl.py
+++ b/workflows/amr/test/test_wdl.py
@@ -194,7 +194,6 @@ class TestAMR(WDLTestCase):
         res = self.run_miniwdl(
             task="RunSpades",
             task_input=inputs,
-            docker_image_id="ghcr.io/chanzuckerberg/czid-workflows/czid-short-read-mngs-public"
         )
 
         with open(res["outputs"]["RunSpades.contigs"]) as contigs_fa:
@@ -213,7 +212,6 @@ class TestAMR(WDLTestCase):
         res = self.run_miniwdl(
             task="RunSpades",
             task_input=inputs,
-            docker_image_id="ghcr.io/chanzuckerberg/czid-workflows/czid-short-read-mngs-public"
         )
 
         with open(res["outputs"]["RunSpades.contigs"]) as contigs_fa:


### PR DESCRIPTION
This PR uses the AMR docker image for the RunSpades task in the AMR workflow; previously the short-read-mngs image had been used. The same version of SPAdes (3.11.1) is now installed on the AMR image.

This fixes an issue where tests for the AMR RunSpades task failed due to their reliance on an updated version of the short-read-mngs image that the test did not have access to. See [CZID-9425](https://czi-tech.atlassian.net/browse/CZID-9425).

[CZID-9425]: https://czi-tech.atlassian.net/browse/CZID-9425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ