### PR TITLE
NT and NR download with blastdbcmd

### DIFF
--- a/workflows/index-generation/Dockerfile
+++ b/workflows/index-generation/Dockerfile
@@ -45,7 +45,9 @@ RUN apt-get update && \
     libbz2-dev \
     liblz4-dev \
     libzstd-dev \
-    clang
+    clang \
+    # needed to download ncbi-blast
+    alien
 
 # based on https://github.com/rust-lang/docker-rust/blob/dcb74d779e8a74263dc8b91d58d8ce7f3c0c805b/1.70.0/buster/Dockerfile
 ENV RUSTUP_HOME=/usr/local/rustup \
@@ -76,6 +78,16 @@ RUN set -eux; \
 COPY ncbi-compress /ncbi-compress
 RUN cd /ncbi-compress && cargo build --release
 
+# ncbi blast
+RUN wget https://ftp.ncbi.nlm.nih.gov/blast/executables/LATEST/ncbi-blast-2.15.0+-3.x86_64.rpm
+RUN wget https://ftp.ncbi.nlm.nih.gov/blast/executables/LATEST/ncbi-blast-2.15.0+-3.x86_64.rpm.md5
+
+RUN md5sum -c ncbi-blast-2.15.0+-3.x86_64.rpm.md5
+
+
+RUN alien ncbi-blast-2.15.0+-3.x86_64.rpm
+RUN dpkg -i ncbi-blast_2.15.0+-4_amd64.deb
+RUN which blastn
 
 FROM ubuntu:22.04
 ARG DEBIAN_FRONTEND

--- a/workflows/index-generation/Dockerfile
+++ b/workflows/index-generation/Dockerfile
@@ -78,20 +78,10 @@ RUN set -eux; \
 COPY ncbi-compress /ncbi-compress
 RUN cd /ncbi-compress && cargo build --release
 
-# ncbi blast
-RUN wget https://ftp.ncbi.nlm.nih.gov/blast/executables/LATEST/ncbi-blast-2.15.0+-3.x86_64.rpm
-RUN wget https://ftp.ncbi.nlm.nih.gov/blast/executables/LATEST/ncbi-blast-2.15.0+-3.x86_64.rpm.md5
-
-RUN md5sum -c ncbi-blast-2.15.0+-3.x86_64.rpm.md5
-
-
-RUN alien ncbi-blast-2.15.0+-3.x86_64.rpm
-RUN dpkg -i ncbi-blast_2.15.0+-4_amd64.deb
-RUN which blastn
-
 FROM ubuntu:22.04
 ARG DEBIAN_FRONTEND
 # Install dependencies
+
 RUN apt-get update && \
     apt-get install -y \
         wget \
@@ -99,7 +89,12 @@ RUN apt-get update && \
         python3-pip \
         mysql-client \
         kraken2 \
+        curl \
         jq
+
+RUN wget https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/LATEST/ncbi-blast-2.15.0+-x64-linux.tar.gz && \
+    tar -xzvf ncbi-blast-2.15.0+-x64-linux.tar.gz && \
+    cp ncbi-blast-2.15.0+/bin/* /usr/local/bin/
 
 COPY --from=builder /diamond/build/diamond /usr/local/bin
 COPY --from=builder /minimap2/minimap2 /usr/local/bin/

--- a/workflows/index-generation/Dockerfile
+++ b/workflows/index-generation/Dockerfile
@@ -45,9 +45,7 @@ RUN apt-get update && \
     libbz2-dev \
     liblz4-dev \
     libzstd-dev \
-    clang \
-    # needed to download ncbi-blast
-    alien
+    clang
 
 # based on https://github.com/rust-lang/docker-rust/blob/dcb74d779e8a74263dc8b91d58d8ce7f3c0c805b/1.70.0/buster/Dockerfile
 ENV RUSTUP_HOME=/usr/local/rustup \

--- a/workflows/index-generation/index-generation.wdl
+++ b/workflows/index-generation/index-generation.wdl
@@ -45,15 +45,19 @@ workflow index_generation {
 
     # Download files if they are not provided
     scatter (file in possibly_zipped_files) {
-        # if filename ends with gz
-        if (sub(basename(file), "\\.gz$", "") != basename(file) && defined(file)) {
-            call UnzipFile {
-                input:
-                zipped_file = file,
-                cpu = 8,
-                docker_image_id = docker_image_id,
+        if (defined(file) && file != "") {
+            # if filename ends with gz
+            String file_ = select_first([file]) # this is safe because we know it's defined and not empty
+            if (sub(basename(file_), "\\.gz$", "") != basename(file_)) {
+                call UnzipFile {
+                    input:
+                    zipped_file = file_,
+                    cpu = 8,
+                    docker_image_id = docker_image_id,
+                }
             }
         }
+
         
         File unzipped_file = select_first([UnzipFile.file, file])
     }

--- a/workflows/index-generation/index-generation.wdl
+++ b/workflows/index-generation/index-generation.wdl
@@ -101,7 +101,7 @@ workflow index_generation {
         call CompressDatabase as CompressNT {
             input:
             database_type = "nt",
-            fasta = nt,
+            fasta = nt_download,
             accession2taxid_files = [unzipped_accession2taxid_nucl_wgs, unzipped_accession2taxid_nucl_gb],
             k = nt_compression_k,
             scaled = nt_compression_scaled,
@@ -149,12 +149,6 @@ workflow index_generation {
         }
     }
 
-    call DownloadDatabase {
-        input:
-        database_type = "nt",
-        docker_image_id = docker_image_id
-    }
-
     call GenerateIndexAccessions {
         input:
         nr = nr_or_compressed,
@@ -199,6 +193,7 @@ workflow index_generation {
         File? nr_contained_in_chunk = CompressNR.contained_in_chunk
         File? nt_contained_in_tree = CompressNT.contained_in_tree
         File? nt_contained_in_chunk = CompressNT.contained_in_chunk
+        File accession2taxid_db = GenerateIndexAccessions.accession2taxid_db
     #     Directory? nt_split_apart_taxid_dir = CompressNT.split_apart_taxid_dir
     #     Directory? nt_sorted_taxid_dir = CompressNT.sorted_taxid_dir
     #     Directory? nr_split_apart_taxid_dir = CompressNR.split_apart_taxid_dir

--- a/workflows/index-generation/index-generation.wdl
+++ b/workflows/index-generation/index-generation.wdl
@@ -45,7 +45,7 @@ workflow index_generation {
 
     # Download files if they are not provided
     scatter (file in possibly_zipped_files) {
-        if (defined(file) && file != "") {
+        if (defined(file) && select_first([file]) != "") {
             # if filename ends with gz
             String file_ = select_first([file]) # this is safe because we know it's defined and not empty
             if (sub(basename(file_), "\\.gz$", "") != basename(file_)) {

--- a/workflows/index-generation/index-generation.wdl
+++ b/workflows/index-generation/index-generation.wdl
@@ -46,7 +46,7 @@ workflow index_generation {
     # Download files if they are not provided
     scatter (file in possibly_zipped_files) {
         # if filename ends with gz
-        if (sub(basename(file), "\\.gz$", "") != basename(file) && file != null) {
+        if (sub(basename(file), "\\.gz$", "") != basename(file) && defined(file)) {
             call UnzipFile {
                 input:
                 zipped_file = file,
@@ -62,15 +62,11 @@ workflow index_generation {
     File unzipped_accession2taxid_pdb = unzipped_file[2]
     File unzipped_accession2taxid_prot = unzipped_file[3]
     File unzipped_taxdump = unzipped_file[4]
-    File provided_nt = unzipped_file[5]
-    File provided_nr = unzipped_file[6]
+    File provided_nt_unzipped = unzipped_file[5]
+    File provided_nr_unzipped = unzipped_file[6]
 
-    Boolean is_nt_provided = defined(provided_nt)
-    Boolean is_nr_provided = defined(provided_nr)
-
-    if (is_nt_provided) {
-        provided_nt = unzipped_nt
-    }
+    Boolean is_nt_provided = defined(provided_nt_unzipped)
+    Boolean is_nr_provided = defined(provided_nr_unzipped)
 
     if (!is_nt_provided) {
         call DownloadDatabase as DownloadNT {
@@ -87,8 +83,8 @@ workflow index_generation {
         }
     }
 
-    File nt_download = select_first([provided_nt, DownloadNT.database])
-    File nr_download = select_first([provided_nr, DownloadNR.database])
+    File nt_download = select_first([provided_nt_unzipped, DownloadNT.database])
+    File nr_download = select_first([provided_nr_unzipped, DownloadNR.database])
 
     if (!skip_protein_compression) {
         call CompressDatabase as CompressNR {

--- a/workflows/index-generation/index-generation.wdl
+++ b/workflows/index-generation/index-generation.wdl
@@ -205,12 +205,13 @@ task DownloadDatabase {
     input {
         String database_type # nt or nr
         String docker_image_id
+        Int threads = 64
     }
 
     command <<<
         set -euxo pipefail
 
-        update_blastdb.pl --decompress ~{database_type} --num_threads 32
+        update_blastdb.pl --decompress ~{database_type} --num_threads ~{threads}
         blastdbcmd -db ~{database_type} -entry all -out ~{database_type}.fsa
 
     >>>
@@ -221,6 +222,7 @@ task DownloadDatabase {
 
     runtime {
         docker: docker_image_id
+        cpu: 64
     }
 
 }

--- a/workflows/index-generation/index-generation.wdl
+++ b/workflows/index-generation/index-generation.wdl
@@ -243,7 +243,12 @@ task UnzipFile {
     }
 
     command <<<
-        pigz -p ~{cpu} -dc ~{zipped_file} > ~{sub(basename(zipped_file), "\\.gz$", "")}
+        set -euxo pipefail
+        output="~{basename(zipped_file)}"
+        curl ~{zipped_file} -o $output
+        pigz -p ~{cpu} -dc $output > ~{sub(basename(zipped_file), "\\.gz$", "")}
+
+	#pigz -p ~{cpu} -dc ~{zipped_file} > ~{sub(basename(zipped_file), "\\.gz$", "")}
     >>>
 
     output {

--- a/workflows/index-generation/index-generation.wdl
+++ b/workflows/index-generation/index-generation.wdl
@@ -22,8 +22,8 @@ workflow index_generation {
         Boolean skip_generate_nt_assets = false
         Boolean logging_enabled = false
 
-        File? provided_nt = ""
-        File? provided_nr = ""
+        File? provided_nt
+        File? provided_nr
         File provided_accession2taxid_nucl_gb = "~{ncbi_server}/pub/taxonomy/accession2taxid/nucl_gb.accession2taxid.gz"
         File provided_accession2taxid_nucl_wgs = "~{ncbi_server}/pub/taxonomy/accession2taxid/nucl_wgs.accession2taxid.gz" 
         File provided_accession2taxid_pdb = "~{ncbi_server}/pub/taxonomy/accession2taxid/pdb.accession2taxid.gz"

--- a/workflows/index-generation/index-generation.wdl
+++ b/workflows/index-generation/index-generation.wdl
@@ -247,8 +247,6 @@ task UnzipFile {
         output="~{basename(zipped_file)}"
         curl ~{zipped_file} -o $output
         pigz -p ~{cpu} -dc $output > ~{sub(basename(zipped_file), "\\.gz$", "")}
-
-	#pigz -p ~{cpu} -dc ~{zipped_file} > ~{sub(basename(zipped_file), "\\.gz$", "")}
     >>>
 
     output {

--- a/workflows/index-generation/test/test_wdl.py
+++ b/workflows/index-generation/test/test_wdl.py
@@ -13,6 +13,8 @@ class TestIndexGeneration(WDLTestCase):
     common_inputs = {
         "index_name": "2020-04-20",
         "ncbi_server": "https://idseq-samples-test.s3-us-west-2.amazonaws.com/index-generation/inputs",
+        "provided_nt": "https://idseq-samples-test.s3-us-west-2.amazonaws.com/index-generation/inputs/blast/nt",
+        "provided_nr": "https://idseq-samples-test.s3-us-west-2.amazonaws.com/index-generation/inputs/blast/nr",
     }
 
     def testIndexGeneration(self):

--- a/workflows/index-generation/test/test_wdl.py
+++ b/workflows/index-generation/test/test_wdl.py
@@ -9,12 +9,14 @@ import marisa_trie
 class TestIndexGeneration(WDLTestCase):
     """Tests the RunValidateInput function"""
 
+    base = "https://idseq-samples-test.s3-us-west-2.amazonaws.com/index-generation/inputs"
+
     wdl = os.path.join(os.path.dirname(__file__), "..", "index-generation.wdl")
     common_inputs = {
         "index_name": "2020-04-20",
-        "ncbi_server": "https://idseq-samples-test.s3-us-west-2.amazonaws.com/index-generation/inputs",
-        "provided_nt": "https://idseq-samples-test.s3-us-west-2.amazonaws.com/index-generation/inputs/blast/db/FASTA/nt.gz",
-        "provided_nr": "https://idseq-samples-test.s3-us-west-2.amazonaws.com/index-generation/inputs/blast/db/FASTA/nr.gz",
+        "ncbi_server": base,
+        "provided_nt": f"{base}/blast/db/FASTA/nt.gz",
+        "provided_nr": f"{base}/blast/db/FASTA/nr.gz",
     }
 
     def testIndexGeneration(self):

--- a/workflows/index-generation/test/test_wdl.py
+++ b/workflows/index-generation/test/test_wdl.py
@@ -13,8 +13,8 @@ class TestIndexGeneration(WDLTestCase):
     common_inputs = {
         "index_name": "2020-04-20",
         "ncbi_server": "https://idseq-samples-test.s3-us-west-2.amazonaws.com/index-generation/inputs",
-        "provided_nt": "https://idseq-samples-test.s3-us-west-2.amazonaws.com/index-generation/inputs/blast/nt",
-        "provided_nr": "https://idseq-samples-test.s3-us-west-2.amazonaws.com/index-generation/inputs/blast/nr",
+        "provided_nt": "https://idseq-samples-test.s3-us-west-2.amazonaws.com/index-generation/inputs/blast/db/FASTA/nt.gz",
+        "provided_nr": "https://idseq-samples-test.s3-us-west-2.amazonaws.com/index-generation/inputs/blast/db/FASTA/nr.gz",
     }
 
     def testIndexGeneration(self):


### PR DESCRIPTION
* add downloading NR and NT using blastdbcmd rather than downloading off FTP site ([source](https://ncbiinsights.ncbi.nlm.nih.gov/2024/01/25/blast-fasta-unavailable-on-ftp/?utm_source=ncbi_twitter&utm_medium=referral&utm_campaign=blast-fasta-unavailable-20240125) mentioning FTP downloads will no longer be supported starting in April)

* tested by running downloadDatabase step and comparing results to NR grabbed off the ftp site. I compared on the size of NR from FTP site which was 339G whereas NR generated through blast cli was 343G I think the difference could be due to the data being pulled during slightly different times, but they are both within a very similar range so i am not too concerned. 