### PR TITLE
Allow multiple arguments to diamond blastx

### DIFF
--- a/lib/idseq_utils/idseq_utils/diamond_scatter.py
+++ b/lib/idseq_utils/idseq_utils/diamond_scatter.py
@@ -3,6 +3,7 @@ See diamond_scatter.md for a detailed description
 """
 
 import os
+import shlex
 import shutil
 import sys
 import errno
@@ -71,8 +72,15 @@ def diamond_blastx(
         database,
         "--out",
         out,
-        f"--{diamond_args}",
     ]
+
+    # backwards compatibility for function calls that expect this function
+    # to automatically append "--" to diamond_args
+    if diamond_args == "long-reads" or diamond_args == "mid-sensitive":
+        diamond_args = "--" + diamond_args
+
+    cmd.extend(shlex.split(diamond_args))
+
     for query in queries:
         cmd += ["--query", query]
     if chunk:

--- a/workflows/diamond/Dockerfile
+++ b/workflows/diamond/Dockerfile
@@ -19,7 +19,6 @@ WORKDIR /tmp
 RUN git clone https://github.com/chanzuckerberg/czid-workflows
 WORKDIR /tmp/czid-workflows
 RUN pip3 install -r requirements-dev.txt
-RUN git checkout rlim-add-diamond-modification
-RUN cp short-read-mngs/idseq_utils/idseq_utils/diamond_scatter.py /usr/local/bin/
+COPY --from=lib idseq_utils/idseq_utils/diamond_scatter.py /usr/local/bin/
 
 WORKDIR /workdir

--- a/workflows/diamond/diamond.wdl
+++ b/workflows/diamond/diamond.wdl
@@ -34,7 +34,7 @@ task RunDiamond {
     }
 
     command <<<
-        python3 /usr/local/bin/diamond_scatter.py blastx-chunk --db ~{db_chunk} --query ~{query_0} ~{if defined(query_1) then '--query ~{query_1}' else ''} --out-dir chunks --diamond-args "~{extra_args}"
+        python3 /usr/local/bin/diamond_scatter.py blastx-chunk --db ~{db_chunk} --query ~{query_0} ~{if defined(query_1) then '--query ~{query_1}' else ''} --out-dir chunks --diamond-args="~{extra_args}"
     >>>
 
     output {


### PR DESCRIPTION
This uses the same `shlex` call we currently use to support multiple arguments in the minimap2 workflow.