### PR TITLE
Parameterize aligner wdl versions

### DIFF
--- a/workflows/long-read-mngs/run.wdl
+++ b/workflows/long-read-mngs/run.wdl
@@ -554,6 +554,7 @@ task RunNTAlignment {
         File? local_minimap2_index
         String prefix
         # only required for remote alignment
+        String minimap2_wdl_version
         String? s3_wd_uri
         String docker_image_id
     }
@@ -573,6 +574,7 @@ task RunNTAlignment {
             result_path="gsnap.paf",
             aligner="minimap2",
             aligner_args="~{minimap2_args}",
+            aligner_wdl_version="~{minimap2_wdl_version}",
             queries=["~{all_sequences_to_align}"],
         )
         CODE
@@ -599,6 +601,7 @@ task RunNRAlignment {
         Boolean run_locally = false
         File? local_diamond_index
         # only required for remote alignment
+        String diamond_wdl_version
         String? s3_wd_uri
         String docker_image_id
     }
@@ -624,6 +627,7 @@ task RunNRAlignment {
             result_path="diamond.m8",
             aligner="diamond",
             aligner_args="~{diamond_args}",
+            aligner_wdl_version="~{diamond_wdl_version}",
             queries=["~{assembled_reads_fa}"],
         )
         CODE
@@ -1299,6 +1303,9 @@ workflow czid_long_read_mngs {
         String? diamond_db
         String diamond_args = "long-reads"
 
+        String diamond_wdl_version = "v1.0.0"
+        String minimap2_wdl_version = "v1.0.0"
+
         Boolean use_deuterostome_filter = true
         Boolean use_taxon_whitelist = false
     }
@@ -1396,6 +1403,7 @@ workflow czid_long_read_mngs {
             run_locally = defined(minimap2_local_db_path),
             local_minimap2_index = minimap2_local_db_path,
             prefix= minimap2_prefix,
+            minimap2_wdl_version=minimap2_wdl_version,
             docker_image_id = docker_image_id,
     }
 
@@ -1406,6 +1414,7 @@ workflow czid_long_read_mngs {
             diamond_args=diamond_args,
             run_locally=defined(diamond_local_db_path),
             local_diamond_index=diamond_local_db_path,
+            diamond_wdl_version=diamond_wdl_version,
             s3_wd_uri=s3_wd_uri,
             docker_image_id=docker_image_id,
     }

--- a/workflows/short-read-mngs/non_host_alignment.wdl
+++ b/workflows/short-read-mngs/non_host_alignment.wdl
@@ -77,6 +77,7 @@ task RunAlignment_minimap2_out {
         Boolean? run_locally = false
         File? local_minimap2_index 
         String prefix
+        String minimap2_wdl_version
     }
 
     command <<<
@@ -96,6 +97,7 @@ task RunAlignment_minimap2_out {
             result_path="gsnap.paf",
             aligner="minimap2",
             aligner_args="~{minimap2_args}",
+            aligner_wdl_version="~{minimap2_wdl_version}",
             queries=["~{sep='", "' fastas}"],
         )
         CODE
@@ -124,6 +126,7 @@ task RunAlignment_diamond_out {
         Boolean? run_locally = false
         File? local_diamond_index
         String prefix
+        String diamond_wdl_version
     }
 
     command <<<
@@ -143,6 +146,7 @@ task RunAlignment_diamond_out {
             result_path="rapsearch2.m8",
             aligner="diamond",
             aligner_args="~{diamond_args}",
+            aligner_wdl_version="~{diamond_wdl_version}",
             queries=["~{sep='", "' fastas}"],
         )
         CODE
@@ -302,6 +306,8 @@ workflow czid_non_host_alignment {
     String diamond_args = "mid-sensitive"
     String minimap2_prefix = "gsnap"
     String diamond_prefix = "rapsearch2"
+    String minimap2_wdl_version = "v1.0.0"
+    String diamond_wdl_version = "v1.0.0"
 
   }
   call RunAlignment_minimap2_out { 
@@ -313,7 +319,8 @@ workflow czid_non_host_alignment {
       minimap2_args = minimap2_args,
       run_locally = defined(minimap2_local_db_path),
       local_minimap2_index = minimap2_local_db_path,
-      prefix= minimap2_prefix
+      prefix= minimap2_prefix,
+      minimap2_wdl_version=minimap2_wdl_version
   }
   call RunCallHitsMinimap2{ 
     input:
@@ -337,6 +344,7 @@ workflow czid_non_host_alignment {
       prefix = diamond_prefix,
       run_locally = defined(diamond_local_db_path),
       local_diamond_index = diamond_local_db_path,
+      diamond_wdl_version=diamond_wdl_version,
       docker_image_id = docker_image_id
   }
   call RunCallHitsDiamond { 


### PR DESCRIPTION
This allows us to specify versions of the diamond or minimap2 WDL workflows that a given version of another workflow (like long-read-mngs or short-read-mngs) depends on. 