### PR TITLE
Output spades log in RunSpades

### DIFF
--- a/workflows/amr/run.wdl
+++ b/workflows/amr/run.wdl
@@ -641,6 +641,7 @@ task RunSpades {
     output { 
         File contigs = "spades/contigs.fasta"
         File? scaffolds = "spades/scaffolds.fasta"
+        File? spades_output_log = "spades/spades.log"
         File? failure_log = "spades_failure.json"
     }
     runtime { 


### PR DESCRIPTION
This log is useful for evaluating SPAdes issues; currently it is output by the short-read-mngs pipeline.