### PR TITLE
check for completed alignment chunks before dispatching them

### DIFF
--- a/lib/idseq_utils/idseq_utils/batch_run_helpers.py
+++ b/lib/idseq_utils/idseq_utils/batch_run_helpers.py
@@ -33,7 +33,9 @@ config = Config(
 
 
 _batch_client = boto3.client("batch", config=config)
-_s3_client = boto3.client("s3")
+# the retries are less necessary for S3 because rate limiting is more generous but we have hit the limit
+#   and it is costly for this job to be re-run
+_s3_client = boto3.client("s3", config=config)
 
 try:
     account_id = boto3.client("sts").get_caller_identity()["Account"]
@@ -203,6 +205,7 @@ def _run_chunk(
         log.info(f"skipping chunk, output already exists: {wdl_output_uri}")
         return
     except ClientError as e:
+        # raise the error if it is anything other than "not found"
         if e.response["Error"]["Code"] != "404":
             raise e
 


### PR DESCRIPTION
Currently, if an alignment coordinator job fails due to a spot interruption the next job reruns all of the alignment chunks. It is likely that chunks will be complete, especially since the jobs are not cancelled and will continue working between retries. This can prevent a lot of redundant work and keep our alignment job queue smaller which should slightly mitigate other issues.