### PR TITLE
Sort bowtie2 outputs for reproducibility

### DIFF
--- a/lib/idseq-dag/idseq_dag/steps/run_assembly.py
+++ b/lib/idseq-dag/idseq_dag/steps/run_assembly.py
@@ -237,7 +237,7 @@ class PipelineStepRunAssembly(PipelineStep):
                 args=samtools_sort_params
             )
         )
-        
+
         contig_stats, _ = generate_info_from_sam(output_bowtie_sam, read2contig, duplicate_cluster_sizes_path=duplicate_cluster_sizes_path)
         with open(output_contig_stats, 'w') as ocf:
             json.dump(contig_stats, ocf)

--- a/lib/idseq-dag/idseq_dag/steps/run_assembly.py
+++ b/lib/idseq-dag/idseq_dag/steps/run_assembly.py
@@ -221,6 +221,23 @@ class PipelineStepRunAssembly(PipelineStep):
                 }
             )
         )
+
+        # sort bowtie2 output file
+        # samtools sort -n -O sam -o bowtie2.sam bowtie2.sam
+        samtools_sort_params = [
+            "sort",
+            "-n",
+            "-O", "sam",
+            "-o", output_bowtie_sam,
+            output_bowtie_sam
+        ]
+        command.execute(
+            command_patterns.SingleCommand(
+                cmd="samtools",
+                args=samtools_sort_params
+            )
+        )
+        
         contig_stats, _ = generate_info_from_sam(output_bowtie_sam, read2contig, duplicate_cluster_sizes_path=duplicate_cluster_sizes_path)
         with open(output_contig_stats, 'w') as ocf:
             json.dump(contig_stats, ocf)

--- a/lib/idseq-dag/idseq_dag/util/m8.py
+++ b/lib/idseq-dag/idseq_dag/util/m8.py
@@ -431,7 +431,7 @@ def generate_taxon_count_json_from_m8(
                 agg_bucket["base_count"],
             }
             if agg_bucket.get('source_count_type'):
-                taxon_counts_row['source_count_type'] = list(agg_bucket['source_count_type'])
+                taxon_counts_row['source_count_type'] = sorted(list(agg_bucket['source_count_type']))
 
             taxon_counts_attributes.append(taxon_counts_row)
         output_dict = {

--- a/workflows/short-read-mngs/host_filter.wdl
+++ b/workflows/short-read-mngs/host_filter.wdl
@@ -276,6 +276,8 @@ task ercc_bowtie2_filter {
 
     ~{bowtie2_invocation}
 
+    samtools sort -n -O sam -o /tmp/bowtie2_ercc.sam /tmp/bowtie2_ercc.sam
+
     # Extract reads [pairs] that did NOT map to the index
     if [[ '~{paired}' == 'true' ]]; then
         #    1 (read paired)


### PR DESCRIPTION
* This PR attempts to make almost all outputs of the short-read-mngs pipeline reproducible when run on the same input. 
* The changes made here are issues in sorting: 
1. sort bowtie2_ercc.sam file 
2. sort bowtie2 output from reads to contig mapping
3. sort list of NT/NR source in output json

The outputs were tested as following:
1. Run 2 pipelines with the same input
2. Run `python3 scripts/compare-outputs.py <output.json> <output2.json>` to compare md5 hashes
3. Manually `diff` files to determine the cause of the discrepancies

The remaining files which are different on every run are: 
czid_short_read_mngs.host_filter.fastp_html
czid_short_read_mngs.postprocess.assembly_out_assembly_spades_output_log

Both of which contain timestamps which account for the discrepancy