### PR TITLE
Add Random Subsampling to Nanopore mNGS Pipeline

### DIFF
--- a/workflows/long-read-mngs/run.wdl
+++ b/workflows/long-read-mngs/run.wdl
@@ -268,7 +268,9 @@ task RunSubsampling {
 
     command <<<
         set -euxo pipefail
-        head -"~{subsample_depth}" "~{input_fastq}" > sample.subsampled.fastq
+
+        # set seed to 42 for reproducibility
+        seqtk sample -s42 "~{input_fastq}" "~{subsample_depth}" > sample.subsampled.fastq
 
         # We should always have reads after subsampling, but adding for consistency with other steps
         filter_count sample.subsampled.fastq subsampled "No reads remaining after subsampling"


### PR DESCRIPTION
Switching from using head for subsampling to using `seqtk sample`. I timed the head vs. seqtk sample approach out on a 6.7 GB nanopore sample and the seqtk option took about 2.3 times longer to run then head, but only took 27 seconds to run. Since 6.7 GB is on the larger side for a nanopore sample i think we're safe subbing out `head` for `seqtk sample`

The long-read-mngs docker container already has seqtk installed, so no changes are needed to add that in there. 

```
root@50040e0c1bc9:/mnt/long-read-mngs# time head -4000000 beefy.sample.validated.fastq > beefy_sample_head.subsampled.fastq

real	0m11.675s
user	0m4.105s
sys	0m7.569s
root@50040e0c1bc9:/mnt/long-read-mngs# time seqtk sample -s42  beefy.sample.validated.fastq 4000000 > beefy_sample_seqtk.subsampled.fastq

real	0m27.252s
user	0m10.956s
sys	0m16.262s
```

ticket: [CZID-9693](https://czi-tech.atlassian.net/jira/software/c/projects/CZID/boards/139?assignee=60a42f7375e875006f1b4497&assignee=605e7b9a2c761b00692c17e1&assignee=712020%3A20e0990a-32ea-416c-81c0-455ec211b9b4&assignee=60495ff3bfef95006bd72f32&assignee=62be1963c9f2df7b608c48b5&assignee=619e9306d2e64c00710d725e&assignee=6107987375ad96006916fecf&assignee=61e257b7567cb70070692d3d&assignee=5d09495d0feacc0c4d1b4807&assignee=60496240ceccdd006a2b896e&assignee=62182f0d505e68006ad79d3b&assignee=60a42e1875e875006f1b2bf1&selectedIssue=CZID-9693)

[CZID-9693]: https://czi-tech.atlassian.net/browse/CZID-9693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


tested on [this](https://staging.czid.org/samples/52003?currentTab=Nanopore&selectedOptions=%7B%22annotations%22%3A%5B%5D%2C%22flags%22%3A%5B%5D%2C%22background%22%3Anull%2C%22categories%22%3A%7B%22categories%22%3A%5B%5D%2C%22subcategories%22%3A%7B%22Viruses%22%3A%5B%5D%7D%7D%2C%22metricShortReads%22%3A%22nt_r%22%2C%22metricLongReads%22%3A%22nt_b%22%2C%22nameType%22%3A%22Scientific%20name%22%2C%22readSpecificity%22%3A0%2C%22taxa%22%3A%5B%5D%2C%22thresholdsShortReads%22%3A%5B%5D%2C%22thresholdsLongReads%22%3A%5B%5D%7D&view=table) sample on staging and cross referenced [this](https://staging.czid.org/samples/52002?currentTab=Nanopore&selectedOptions=%7B%22annotations%22%3A%5B%5D%2C%22flags%22%3A%5B%5D%2C%22background%22%3Anull%2C%22categories%22%3A%7B%22categories%22%3A%5B%5D%2C%22subcategories%22%3A%7B%22Viruses%22%3A%5B%5D%7D%7D%2C%22metricShortReads%22%3A%22nt_r%22%2C%22metricLongReads%22%3A%22nt_b%22%2C%22nameType%22%3A%22Scientific%20name%22%2C%22readSpecificity%22%3A0%2C%22taxa%22%3A%5B%5D%2C%22thresholdsShortReads%22%3A%5B%5D%2C%22thresholdsLongReads%22%3A%5B%5D%7D&view=table) sample that used the existing subsampling scheme to verify that new approach gave similar results 