### PR TITLE
Re-Attach to running alignment chunks on retry

### DIFF
--- a/lib/idseq_utils/idseq_utils/batch_run_helpers.py
+++ b/lib/idseq_utils/idseq_utils/batch_run_helpers.py
@@ -110,7 +110,7 @@ class BatchJobCache:
     def get(self, batch_args: Dict) -> Optional[str]:
         try:
             resp = _s3_client.get_object(Bucket=self.bucket, Key=self._key(batch_args))
-            resp["Body"].read().decode()
+            return resp["Body"].read().decode()
         except ClientError as e:
             if e.response["Error"]["Code"] == "NoSuchKey":
                 return None

--- a/lib/idseq_utils/idseq_utils/batch_run_helpers.py
+++ b/lib/idseq_utils/idseq_utils/batch_run_helpers.py
@@ -21,6 +21,7 @@ from botocore.exceptions import ClientError
 from botocore.config import Config
 
 log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
 
 MAX_CHUNKS_IN_FLIGHT = 30  # TODO: remove this constant, currently does nothing since we have at most 30 index chunks
 
@@ -324,6 +325,7 @@ def run_alignment(
     for fn in listdir("chunks"):
         if fn.endswith("json"):
             os.remove(os.path.join("chunks", fn))
+            log.debug(f"deleting from S3: {os.path.join(chunk_dir, fn)} ({chunk_dir}, {fn})")
             _s3_client.put_object_tagging(
                 Bucket=bucket,
                 Key=os.path.join(chunk_dir, fn),

--- a/lib/idseq_utils/idseq_utils/batch_run_helpers.py
+++ b/lib/idseq_utils/idseq_utils/batch_run_helpers.py
@@ -7,7 +7,6 @@ import re
 import requests
 import shutil
 import time
-import sys
 from os import listdir
 from multiprocessing import Pool
 from subprocess import run
@@ -20,6 +19,9 @@ from idseq_utils.minimap2_scatter import minimap2_merge
 import boto3
 from botocore.exceptions import ClientError
 from botocore.config import Config
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
 
 MAX_CHUNKS_IN_FLIGHT = 30  # TODO: remove this constant, currently does nothing since we have at most 30 index chunks
 
@@ -63,7 +65,7 @@ def _get_job_status(job_id, use_batch_api=False):
     if use_batch_api:
         jobs = _batch_client.describe_jobs(jobs=[job_id])["jobs"]
         if not jobs:
-            print(f"missing_job_description_from_api: {job_id}", file=sys.stderr)
+            log.debug(f"missing_job_description_from_api: {job_id}")
             return "SUBMITTED"
         return jobs[0]["status"]
     batch_job_desc_bucket = boto3.resource("s3").Bucket(
@@ -76,7 +78,7 @@ def _get_job_status(job_id, use_batch_api=False):
     except ClientError as e:
         if e.response["Error"]["Code"] == "NoSuchKey":
             # Warn that the object is missing so any issue with the s3 mechanism can be identified
-            print(f"missing_job_description_object key: {key}", file=sys.stderr)
+            log.debug(f"missing_job_description_object key: {key}")
             # Return submitted because a missing job status probably means it hasn't been added yet
             return "SUBMITTED"
         else:
@@ -146,7 +148,9 @@ def _run_batch_job(
         cache.put(submit_args, job_id)
 
     def _log_status(status: str):
-        print(
+        level = logging.INFO if status != "FAILED" else logging.ERROR
+        log.log(
+            level,
             "batch_job_status " + json.dumps(
                 {
                     "job_id": job_id,
@@ -157,7 +161,6 @@ def _run_batch_job(
                     "environment": environment,
                 }
             ),
-            file=sys.stderr,
         )
 
     _log_status("SUBMITTED")
@@ -174,12 +177,11 @@ def _run_batch_job(
         except ClientError as e:
             # If we get throttled, randomly wait to de-synchronize the requests
             if e.response["Error"]["Code"] == "TooManyRequestsException":
-                print(f"describe_jobs_rate_limit_error for job_id: {job_id}", file=sys.stderr)
+                log.warn(f"describe_jobs_rate_limit_error for job_id: {job_id}")
                 # Possibly implement a backoff here if throttling becomes an issue
             else:
-                print(
+                log.error(
                     f"unexpected_client_error_while_polling_job_status for job_id: {job_id}",
-                    file=sys.stderr,
                 )
                 raise e
 
@@ -282,7 +284,7 @@ def _run_chunk(
 def _db_chunks(bucket: str, prefix):
     s3_client = boto3.client("s3")
     paginator = s3_client.get_paginator("list_objects_v2")
-    print("db chunks", file=sys.stderr)
+    log.debug("db chunks")
 
     for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
         for obj in page["Contents"]:
@@ -323,7 +325,7 @@ def run_alignment(
     for fn in listdir("chunks"):
         if fn.endswith("json"):
             os.remove(os.path.join("chunks", fn))
-            print(f"deleting from S3: {os.path.join(chunk_dir, fn)} ({chunk_dir}, {fn})", file=sys.stderr)
+            log.debug(f"deleting from S3: {os.path.join(chunk_dir, fn)} ({chunk_dir}, {fn})")
             _s3_client.put_object_tagging(
                 Bucket=bucket,
                 Key=os.path.join(chunk_dir, fn),

--- a/lib/idseq_utils/idseq_utils/batch_run_helpers.py
+++ b/lib/idseq_utils/idseq_utils/batch_run_helpers.py
@@ -91,18 +91,18 @@ class BatchJobCache:
     The output should always be the same if the inputs are the same, however we also incorporate the batch_args
     into the cache because a retry on spot vs on demand will result in a different batch queue.
     """
-    def __init__(self, bucket: str, prefix: str, inputs: dict[str, str]):
+    def __init__(self, bucket: str, prefix: str, inputs: Dict[str, str]):
         self.bucket = bucket
         self.prefix = prefix
         self.inputs = inputs
 
-    def _key(self, batch_args: dict) -> str:
+    def _key(self, batch_args: Dict) -> str:
         hash = hashlib.sha256()
         cache_dict = {"inputs": self.inputs, "batch_args": batch_args}
         hash.update(json.dumps(cache_dict, sort_keys=True).encode())
         return os.path.join(self.prefix, hash.hexdigest())
 
-    def get(self, batch_args: dict) -> Optional[str]:
+    def get(self, batch_args: Dict) -> Optional[str]:
         try:
             resp = _s3_client.get_object(Bucket=self.bucket, Key=self._key(batch_args))
             resp["Body"].read().decode()
@@ -112,7 +112,7 @@ class BatchJobCache:
             else:
                 raise e
 
-    def put(self, batch_args: dict, job_id: str):
+    def put(self, batch_args: Dict, job_id: str):
         _s3_client.put_object(
             Bucket=self.bucket,
             Key=self._key(batch_args),

--- a/lib/idseq_utils/idseq_utils/batch_run_helpers.py
+++ b/lib/idseq_utils/idseq_utils/batch_run_helpers.py
@@ -20,8 +20,12 @@ import boto3
 from botocore.exceptions import ClientError
 from botocore.config import Config
 
+logging.basicConfig(
+    level=logging.DEBUG,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S',
+)
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 MAX_CHUNKS_IN_FLIGHT = 30  # TODO: remove this constant, currently does nothing since we have at most 30 index chunks
 

--- a/lib/idseq_utils/idseq_utils/batch_run_helpers.py
+++ b/lib/idseq_utils/idseq_utils/batch_run_helpers.py
@@ -319,9 +319,16 @@ def run_alignment(
     run(["s3parcp", "--recursive", chunk_dir, "chunks"], check=True)
     if os.path.exists(os.path.join("chunks", "cache")):
         shutil.rmtree(os.path.join("chunks", "cache"))
+    if os.path.exists(os.path.join("chunks", "batch_job_cache")):
+        shutil.rmtree(os.path.join("chunks", "batch_job_cache"))
     for fn in listdir("chunks"):
         if fn.endswith("json"):
             os.remove(os.path.join("chunks", fn))
+            _s3_client.put_object_tagging(
+                Bucket=bucket,
+                Key=os.path.join(chunk_dir, fn),
+                Tagging={"TagSet": [{"Key": "AlignmentCoordination", "Value": "True"}]},
+            )
     if aligner == "diamond":
         blastx_join("chunks", result_path, aligner_args, *queries)
     else:

--- a/lib/idseq_utils/idseq_utils/batch_run_helpers.py
+++ b/lib/idseq_utils/idseq_utils/batch_run_helpers.py
@@ -101,19 +101,15 @@ class BatchJobCache:
         self.prefix = prefix
         self.inputs = inputs
 
-    def _cache_value(self, batch_args: Dict) -> str:
-        return json.dumps({"inputs": self.inputs, "batch_args": batch_args}, sort_keys=True)
-
     def _key(self, batch_args: Dict) -> str:
         hash = hashlib.sha256()
-        hash.update(self._cache_value(batch_args).encode())
+        cache_dict = {"inputs": self.inputs, "batch_args": batch_args}
+        hash.update(json.dumps(cache_dict, sort_keys=True).encode())
         return os.path.join(self.prefix, hash.hexdigest())
 
     def get(self, batch_args: Dict) -> Optional[str]:
-        key = self._key(batch_args)
-        log.info(f"cache_get ({key}): {self._cache_value(batch_args)}")
         try:
-            resp = _s3_client.get_object(Bucket=self.bucket, Key=key)
+            resp = _s3_client.get_object(Bucket=self.bucket, Key=self._key(batch_args))
             resp["Body"].read().decode()
         except ClientError as e:
             if e.response["Error"]["Code"] == "NoSuchKey":
@@ -122,11 +118,9 @@ class BatchJobCache:
                 raise e
 
     def put(self, batch_args: Dict, job_id: str):
-        key = self._key(batch_args)
-        log.info(f"cache_put ({key}, {job_id}): {self._cache_value(batch_args)}")
         _s3_client.put_object(
             Bucket=self.bucket,
-            Key=key,
+            Key=self._key(batch_args),
             Body=job_id.encode(),
             Tagging="AlignmentCoordination=True",
         )


### PR DESCRIPTION
I went through a few iterations of this but I think the simplest way is to base the approach on a cache. We don't want to make the same batch call twice. The first batch call puts a job on the spot queue, the second the on-demand queue. Also if for whatever reason we change the job definition or inputs that is also part of the cache key.

I also added the convention of adding the tag `AlignmentCoordination=True` to these files so we can clean them with a lifecycle policy. More for cleanliness than cost. I am not sure what convention you are using. Does this make sense @rzlim08 ?