### PR TITLE
Fix alignment batch tagging

### DIFF
--- a/lib/idseq_utils/idseq_utils/batch_run_helpers.py
+++ b/lib/idseq_utils/idseq_utils/batch_run_helpers.py
@@ -110,7 +110,7 @@ class BatchJobCache:
     def get(self, batch_args: Dict) -> Optional[str]:
         try:
             resp = _s3_client.get_object(Bucket=self.bucket, Key=self._key(batch_args))
-            resp["Body"].read().decode()
+            return resp["Body"].read().decode()
         except ClientError as e:
             if e.response["Error"]["Code"] == "NoSuchKey":
                 return None

--- a/lib/idseq_utils/idseq_utils/batch_run_helpers.py
+++ b/lib/idseq_utils/idseq_utils/batch_run_helpers.py
@@ -306,9 +306,9 @@ def run_alignment(
     aligner_wdl_version: str,
     queries: List[str],
 ):
-    bucket, prefix = _bucket_and_key(db_path)
+    db_bucket, db_prefix = _bucket_and_key(db_path)
     chunk_dir = os.path.join(input_dir, f"{aligner}-chunks")
-    _, chunk_prefix = _bucket_and_key(chunk_dir)
+    chunk_bucket, chunk_prefix = _bucket_and_key(chunk_dir)
     chunks = (
         [
             input_dir,
@@ -318,9 +318,9 @@ def run_alignment(
             aligner_wdl_version,
             queries,
             chunk_id,
-            f"s3://{bucket}/{db_chunk}",
+            f"s3://{db_bucket}/{db_chunk}",
         ]
-        for chunk_id, db_chunk in enumerate(_db_chunks(bucket, prefix))
+        for chunk_id, db_chunk in enumerate(_db_chunks(db_bucket, db_prefix))
     )
     with Pool(MAX_CHUNKS_IN_FLIGHT) as p:
         p.starmap(_run_chunk, chunks)
@@ -334,7 +334,7 @@ def run_alignment(
             os.remove(os.path.join("chunks", fn))
             try:
                 _s3_client.put_object_tagging(
-                    Bucket=bucket,
+                    Bucket=chunk_bucket,
                     Key=os.path.join(chunk_prefix, fn),
                     Tagging={"TagSet": [{"Key": "AlignmentCoordination", "Value": "True"}]},
                 )
@@ -345,3 +345,4 @@ def run_alignment(
         blastx_join("chunks", result_path, aligner_args, *queries)
     else:
         minimap2_merge("chunks", result_path, aligner_args, *queries)
+

--- a/lib/idseq_utils/idseq_utils/batch_run_helpers.py
+++ b/lib/idseq_utils/idseq_utils/batch_run_helpers.py
@@ -339,7 +339,7 @@ def run_alignment(
                     Tagging={"TagSet": [{"Key": "AlignmentCoordination", "Value": "True"}]},
                 )
             except ClientError as e:
-                log.error(f"failed to tag '{os.path.join(chunk_prefix, fn)}'")
+                log.error(f"failed to tag 's3://{chunk_bucket}/{os.path.join(chunk_prefix, fn)}'")
                 raise e
     if aligner == "diamond":
         blastx_join("chunks", result_path, aligner_args, *queries)

--- a/lib/idseq_utils/idseq_utils/batch_run_helpers.py
+++ b/lib/idseq_utils/idseq_utils/batch_run_helpers.py
@@ -345,4 +345,3 @@ def run_alignment(
         blastx_join("chunks", result_path, aligner_args, *queries)
     else:
         minimap2_merge("chunks", result_path, aligner_args, *queries)
-


### PR DESCRIPTION
This object tagging was breaking because it was using the bucket from the index which in practice is usually different from the samples bucket. I was able to repro the issue and fix it on one of the failed samples and I added some more logging because this code has given me trouble before.